### PR TITLE
add the fixer NoSpaceBeforeComma

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ No break space are placed before `:`, thin no break space before `;`, `!` and `?
 
 NoSpaceBeforeComma
 ------------------
-Remove space before a `,` and add a non breaking spaces after.
+Remove space before a `,` and add a space after.
 
 Hyphen (automatic hyphenation)
 ------------------------------
@@ -147,7 +147,7 @@ en_GB
 -----
 
 ```php
-$fixer = new Fixer(array('Ellipsis', 'Dimension', 'Dash', 'EnglishQuotes', 'NoSpaceBeforeComma',  'CurlyQuote', 'Hyphen', 'Trademark'));
+$fixer = new Fixer(array('Ellipsis', 'Dimension', 'Dash', 'EnglishQuotes', 'NoSpaceBeforeComma', 'CurlyQuote', 'Hyphen', 'Trademark'));
 $fixer->setLocale('en_GB'); // Needed by the Hyphen Fixer
 ```
 
@@ -157,7 +157,7 @@ fr_FR
 Those rules apply most of the recommendations of "Abrégé du code typographique à l'usage de la presse", ISBN: 9782351130667.
 
 ```php
-$fixer = new Fixer(array('Ellipsis', 'Dimension', 'Dash', 'FrenchQuotes', 'FrenchNoBreakSpace', 'NoSpaceBeforeComma',   'CurlyQuote', 'Hyphen', 'Trademark'));
+$fixer = new Fixer(array('Ellipsis', 'Dimension', 'Dash', 'FrenchQuotes', 'FrenchNoBreakSpace', 'NoSpaceBeforeComma', 'CurlyQuote', 'Hyphen', 'Trademark'));
 $fixer->setLocale('fr_FR'); // Needed by the Hyphen Fixer
 ```
 
@@ -167,7 +167,7 @@ fr_CA
 Mostly the same as fr_FR, but the space before punctuation points is not mandatory.
 
 ```php
-$fixer = new Fixer(array('Ellipsis', 'Dimension', 'Dash', 'FrenchQuotes', 'NoSpaceBeforeComma',   'CurlyQuote', 'Hyphen', 'Trademark'));
+$fixer = new Fixer(array('Ellipsis', 'Dimension', 'Dash', 'FrenchQuotes', 'NoSpaceBeforeComma', 'CurlyQuote', 'Hyphen', 'Trademark'));
 $fixer->setLocale('fr_CA'); // Needed by the Hyphen Fixer
 ```
 
@@ -177,7 +177,7 @@ de_DE
 Mostly the same as en_GB, according to [Typefacts](http://typefacts.com/) and [Wikipedia](http://de.wikipedia.org/wiki/Typografie_f%C3%BCr_digitale_Texte).
 
 ```php
-$fixer = new Fixer(array('Ellipsis', 'Dimension', 'Dash', 'GermanQuotes', 'NoSpaceBeforeComma',   'CurlyQuote', 'Hyphen', 'Trademark'));
+$fixer = new Fixer(array('Ellipsis', 'Dimension', 'Dash', 'GermanQuotes', 'NoSpaceBeforeComma', 'CurlyQuote', 'Hyphen', 'Trademark'));
 $fixer->setLocale('de_DE'); // Needed by the Hyphen Fixer
 ```
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ FrenchNoBreakSpace
 Replace some classic spaces by non breaking spaces following the French typographic code.
 No break space are placed before `:`, thin no break space before `;`, `!` and `?`.
 
+NoSpaceBeforeComma
+------------------
+Remove space before a `,` and add a non breaking spaces after.
+
 Hyphen (automatic hyphenation)
 ------------------------------
 
@@ -143,7 +147,7 @@ en_GB
 -----
 
 ```php
-$fixer = new Fixer(array('Ellipsis', 'Dimension', 'Dash', 'EnglishQuotes', 'CurlyQuote', 'Hyphen', 'Trademark'));
+$fixer = new Fixer(array('Ellipsis', 'Dimension', 'Dash', 'EnglishQuotes', 'NoSpaceBeforeComma',  'CurlyQuote', 'Hyphen', 'Trademark'));
 $fixer->setLocale('en_GB'); // Needed by the Hyphen Fixer
 ```
 
@@ -153,7 +157,7 @@ fr_FR
 Those rules apply most of the recommendations of "Abrégé du code typographique à l'usage de la presse", ISBN: 9782351130667.
 
 ```php
-$fixer = new Fixer(array('Ellipsis', 'Dimension', 'Dash', 'FrenchQuotes', 'FrenchNoBreakSpace', 'CurlyQuote', 'Hyphen', 'Trademark'));
+$fixer = new Fixer(array('Ellipsis', 'Dimension', 'Dash', 'FrenchQuotes', 'FrenchNoBreakSpace', 'NoSpaceBeforeComma',   'CurlyQuote', 'Hyphen', 'Trademark'));
 $fixer->setLocale('fr_FR'); // Needed by the Hyphen Fixer
 ```
 
@@ -163,7 +167,7 @@ fr_CA
 Mostly the same as fr_FR, but the space before punctuation points is not mandatory.
 
 ```php
-$fixer = new Fixer(array('Ellipsis', 'Dimension', 'Dash', 'FrenchQuotes', 'CurlyQuote', 'Hyphen', 'Trademark'));
+$fixer = new Fixer(array('Ellipsis', 'Dimension', 'Dash', 'FrenchQuotes', 'NoSpaceBeforeComma',   'CurlyQuote', 'Hyphen', 'Trademark'));
 $fixer->setLocale('fr_CA'); // Needed by the Hyphen Fixer
 ```
 
@@ -173,7 +177,7 @@ de_DE
 Mostly the same as en_GB, according to [Typefacts](http://typefacts.com/) and [Wikipedia](http://de.wikipedia.org/wiki/Typografie_f%C3%BCr_digitale_Texte).
 
 ```php
-$fixer = new Fixer(array('Ellipsis', 'Dimension', 'Dash', 'GermanQuotes', 'CurlyQuote', 'Hyphen', 'Trademark'));
+$fixer = new Fixer(array('Ellipsis', 'Dimension', 'Dash', 'GermanQuotes', 'NoSpaceBeforeComma',   'CurlyQuote', 'Hyphen', 'Trademark'));
 $fixer->setLocale('de_DE'); // Needed by the Hyphen Fixer
 ```
 

--- a/src/JoliTypo/Fixer/NoSpaceBeforeComma.php
+++ b/src/JoliTypo/Fixer/NoSpaceBeforeComma.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace JoliTypo\Fixer;
+
+use JoliTypo\Fixer;
+use JoliTypo\FixerInterface;
+use JoliTypo\StateBag;
+
+/**
+ * NO_SPACE before ,
+ * As recommended by "Abrégé du code typographique à l'usage de la presse", ISBN: 978-2351130667
+ *
+ * @package JoliTypo\Fixer
+ */
+class NoSpaceBeforeComma implements FixerInterface
+{
+    public function fix($content, StateBag $state_bag = null)
+    {
+        $content = preg_replace('@(\w+) *(,) *'.Fixer::NO_BREAK_SPACE.'*@mu', '$1$2'.Fixer::NO_BREAK_SPACE, $content);
+
+        return $content;
+    }
+}

--- a/src/JoliTypo/Fixer/NoSpaceBeforeComma.php
+++ b/src/JoliTypo/Fixer/NoSpaceBeforeComma.php
@@ -16,7 +16,7 @@ class NoSpaceBeforeComma implements FixerInterface
 {
     public function fix($content, StateBag $state_bag = null)
     {
-        $content = preg_replace('@(\w+) *(,) *'.Fixer::NO_BREAK_SPACE.'*@mu', '$1$2'.Fixer::NO_BREAK_SPACE, $content);
+        $content = preg_replace('@(\w+) *(,) *'.Fixer::NO_BREAK_SPACE.'*@mu', '$1$2 ', $content);
 
         return $content;
     }

--- a/tests/JoliTypo/Tests/Fixer/NoSpaceBeforeCommaTests.php
+++ b/tests/JoliTypo/Tests/Fixer/NoSpaceBeforeCommaTests.php
@@ -1,0 +1,20 @@
+<?php
+namespace JoliTypo\Tests\Fixer;
+
+use JoliTypo\Fixer;
+
+/**
+ * @package JoliTypo\Tests\Fixer
+ */
+class NoSpaceBeforeCommaTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSimpleString()
+    {
+        $fixer = new Fixer\NoSpaceBeforeComma();
+        $this->assertInstanceOf('JoliTypo\Fixer\NoSpaceBeforeComma', $fixer);
+
+        $this->assertEquals("Superman,".Fixer::NO_BREAK_SPACE."you're my hero", $fixer->fix("Superman,you're my hero"));
+        $this->assertEquals("Superman,".Fixer::NO_BREAK_SPACE."you're my hero", $fixer->fix("Superman ,you're my hero"));
+        $this->assertEquals("Superman,".Fixer::NO_BREAK_SPACE."you're my hero", $fixer->fix("Superman  ,  you're my hero"));
+    }
+}


### PR DESCRIPTION
Hello,

This PR manage spaces before and after a comma. 
Like you can see in tests `Superman    ,  you're my hero` become `Superman, you're my hero`