### PR TITLE
Add No Break Space inside french quotes automaticaly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 ### ??? ###
 
 * new NoSpaceBeforeComma fixer, cleaning badly placed spaces close to commas
+* add NoBreakSpace inside french quotes automatically
 
 ### 0.1.4 (2014-06-17) ###
 

--- a/src/JoliTypo/Fixer/FrenchNoBreakSpace.php
+++ b/src/JoliTypo/Fixer/FrenchNoBreakSpace.php
@@ -9,6 +9,8 @@ use JoliTypo\StateBag;
 /**
  * NO_BREAK_SPACE before :
  * NO_BREAK_THIN_SPACE before ; : ! ?
+ * NO_BREAK_SPACE inside « »
+ *
  * As recommended by "Abrégé du code typographique à l'usage de la presse", ISBN: 978-2351130667
  *
  * @package JoliTypo\Fixer
@@ -17,8 +19,13 @@ class FrenchNoBreakSpace implements FixerInterface
 {
     public function fix($content, StateBag $state_bag = null)
     {
-        $content = preg_replace('@[\s'.Fixer::NO_BREAK_SPACE.Fixer::NO_BREAK_THIN_SPACE.']+(:)@mu', Fixer::NO_BREAK_SPACE.'$1', $content);
-        $content = preg_replace('@[\s'.Fixer::NO_BREAK_SPACE.Fixer::NO_BREAK_THIN_SPACE.']+([;!\?])@mu', Fixer::NO_BREAK_THIN_SPACE.'$1', $content);
+        $spaces = '\s'.Fixer::NO_BREAK_SPACE.Fixer::NO_BREAK_THIN_SPACE;
+
+        $content = preg_replace('@['.$spaces.']+(:)@mu', Fixer::NO_BREAK_SPACE.'$1', $content);
+        $content = preg_replace('@['.$spaces.']+([;!\?])@mu', Fixer::NO_BREAK_THIN_SPACE.'$1', $content);
+
+        $content = preg_replace('@'.Fixer::LAQUO.'['.$spaces.']?@mu', Fixer::LAQUO.Fixer::NO_BREAK_SPACE, $content);
+        $content = preg_replace('@['.$spaces.']?'.Fixer::RAQUO.'@mu', Fixer::NO_BREAK_SPACE.Fixer::RAQUO, $content);
 
         return $content;
     }

--- a/tests/JoliTypo/Tests/FrenchTest.php
+++ b/tests/JoliTypo/Tests/FrenchTest.php
@@ -108,4 +108,31 @@ HTML;
 
         $this->assertEquals($fixed, $fixer->fix($to_fix));
     }
+
+    /**
+     * @see https://github.com/jolicode/JoliTypo/issues/16
+     */
+    public function testNoBreakingSpaceInsideGoodQuotes()
+    {
+        $fixer = new Fixer($this->fr_fixers);
+
+        $fixer->setLocale('fr');
+        $this->assertInstanceOf('JoliTypo\Fixer', $fixer);
+
+        $fixed = <<<HTML
+&laquo;&nbsp;test&nbsp;&raquo; et &laquo;&nbsp;test&nbsp;&raquo; sont dans un bateau.
+HTML;
+
+        $to_fix = <<<HTML
+« test » et «test» sont dans un bateau.
+HTML;
+
+        $this->assertEquals($fixed, $fixer->fix($to_fix));
+
+        $to_fix = <<<HTML
+&laquo; test &raquo; et &laquo;test&raquo; sont dans un bateau.
+HTML;
+
+        $this->assertEquals($fixed, $fixer->fix($to_fix));
+    }
 }


### PR DESCRIPTION
Ref #16 

If there is wellformed `« »` but no NO_BREAK_SPACE, we add them automatically.