### PR TITLE
Add NumericFixer to add Non Breaking Space between numeric and unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ CHANGELOG
 
 ### ??? ###
 
+* add Numeric fixer, adding NoBreakSpace between numeric and their units, fix #15
+
 ### 0.2.0 (2015-07-13) ###
 
 * new NoSpaceBeforeComma fixer, cleaning badly placed spaces close to commas

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ $fixed_content = $fixer->fix('<p>"Tell me Mr. Anderson... what good is a phone c
 It's designed to be:
 
 - language agnostic (you can fix `fr_FR`, `fr_CA`, `en_US`... You tell JoliTypo what to fix);
-- fully tested;
 - easy to integrate into modern PHP project (composer and autoload);
 - robust (make use of `\DOMDocument` instead of parsing HTML with dummy regexp);
 - smart enough to avoid Javascript, Code, CSS processing... (configurable protected tags list);
+- fully tested;
 - fully open and usable in any project (MIT License).
 
 [![Build Status](https://travis-ci.org/jolicode/JoliTypo.png?branch=master)](https://travis-ci.org/jolicode/JoliTypo)
@@ -60,7 +60,7 @@ composer require jolicode/jolitypo "~0.2.0"
 
 *Usage outside composer is also possible, just add the `src/` directory to any PSR-0 compatible autoloader.*
 
-Integration
+Integrations
 ===========
 
 - (Official) [Symfony2 Bundle and twig extension](https://github.com/jolicode/JoliTypoBundle)
@@ -139,6 +139,11 @@ Trademark
 Handle trade­mark symbol `™`, a reg­is­tered trade­mark symbol `®`, and a copy­right symbol `©`. This fixer replace
 commonly used approximations: `(r)`, `(c)` and `(TM)`. A non-breaking space is put between numbers and copyright symbol too.
 
+Numeric
+---------
+
+Add a non-breaking space between a numeric and it's unit. Like this: `12_h`, `42_฿` or `88_%`.
+
 **It is really easy to make your own Fixers, feel free to extend the provided ones if they do not fit your typographic rules.**
 
 Fixer recommendations by locale
@@ -148,7 +153,7 @@ en_GB
 -----
 
 ```php
-$fixer = new Fixer(array('Ellipsis', 'Dimension', 'Dash', 'EnglishQuotes', 'NoSpaceBeforeComma', 'CurlyQuote', 'Hyphen', 'Trademark'));
+$fixer = new Fixer(array('Ellipsis', 'Dimension', 'Numeric', 'Dash', 'EnglishQuotes', 'NoSpaceBeforeComma', 'CurlyQuote', 'Hyphen', 'Trademark'));
 $fixer->setLocale('en_GB'); // Needed by the Hyphen Fixer
 ```
 
@@ -158,7 +163,7 @@ fr_FR
 Those rules apply most of the recommendations of "Abrégé du code typographique à l'usage de la presse", ISBN: 9782351130667.
 
 ```php
-$fixer = new Fixer(array('Ellipsis', 'Dimension', 'Dash', 'FrenchQuotes', 'FrenchNoBreakSpace', 'NoSpaceBeforeComma', 'CurlyQuote', 'Hyphen', 'Trademark'));
+$fixer = new Fixer(array('Ellipsis', 'Dimension', 'Numeric', 'Dash', 'FrenchQuotes', 'FrenchNoBreakSpace', 'NoSpaceBeforeComma', 'CurlyQuote', 'Hyphen', 'Trademark'));
 $fixer->setLocale('fr_FR'); // Needed by the Hyphen Fixer
 ```
 
@@ -168,7 +173,7 @@ fr_CA
 Mostly the same as fr_FR, but the space before punctuation points is not mandatory.
 
 ```php
-$fixer = new Fixer(array('Ellipsis', 'Dimension', 'Dash', 'FrenchQuotes', 'NoSpaceBeforeComma', 'CurlyQuote', 'Hyphen', 'Trademark'));
+$fixer = new Fixer(array('Ellipsis', 'Dimension', 'Numeric', 'Dash', 'FrenchQuotes', 'NoSpaceBeforeComma', 'CurlyQuote', 'Hyphen', 'Trademark'));
 $fixer->setLocale('fr_CA'); // Needed by the Hyphen Fixer
 ```
 
@@ -178,7 +183,7 @@ de_DE
 Mostly the same as en_GB, according to [Typefacts](http://typefacts.com/) and [Wikipedia](http://de.wikipedia.org/wiki/Typografie_f%C3%BCr_digitale_Texte).
 
 ```php
-$fixer = new Fixer(array('Ellipsis', 'Dimension', 'Dash', 'GermanQuotes', 'NoSpaceBeforeComma', 'CurlyQuote', 'Hyphen', 'Trademark'));
+$fixer = new Fixer(array('Ellipsis', 'Dimension', 'Numeric', 'Dash', 'GermanQuotes', 'NoSpaceBeforeComma', 'CurlyQuote', 'Hyphen', 'Trademark'));
 $fixer->setLocale('de_DE'); // Needed by the Hyphen Fixer
 ```
 
@@ -233,10 +238,10 @@ $fixed_content  = $fixer->fix("<p>Fixed...</p> <pre>Not fixed...</pre> <p>Fixed.
 Add your own Fixer / Contribute a Fixer
 =======================================
 
-- Write test
-- A Fixer is run on a piece of text, no HTML to deal with
-- Implement `JoliTypo\FixerInterface`
-- Pull request
+- Write test;
+- A Fixer is run on a piece of text, no HTML to deal with;
+- Implement `JoliTypo\FixerInterface`;
+- Pull request;
 - PROFIT!!!
 
 Compatibility & OS support restrictions

--- a/TODO.md
+++ b/TODO.md
@@ -9,7 +9,7 @@ Global
 - [x] Improve the EnglishTest;
 - [ ] Add more pre-configured locale in the README, with the appropriate tests;
 - [ ] Add a http://cldr.unicode.org/ Fixer for number formatting (thx @g_marty for the tip!);
-- [ ] A website in with you copy some HTML and get a fixed HTML outputted;
+- [x] A website in with you copy some HTML and get a fixed HTML outputted;
 - [ ] Allow to apply thoses rules: http://en.wikipedia.org/wiki/Non-English_usage_of_quotation_marks#Hungarian and document them
 
 Locale to improve

--- a/TODO.md
+++ b/TODO.md
@@ -9,7 +9,7 @@ Global
 - [x] Improve the EnglishTest;
 - [ ] Add more pre-configured locale in the README, with the appropriate tests;
 - [ ] Add a http://cldr.unicode.org/ Fixer for number formatting (thx @g_marty for the tip!);
-- [x] A website in with you copy some HTML and get a fixed HTML outputted;
+- [x] A website in which you copy some HTML and get a fixed HTML outputted;
 - [ ] Allow to apply thoses rules: http://en.wikipedia.org/wiki/Non-English_usage_of_quotation_marks#Hungarian and document them
 
 Locale to improve

--- a/src/JoliTypo/Fixer.php
+++ b/src/JoliTypo/Fixer.php
@@ -26,6 +26,7 @@ class Fixer
     const TRADE               = "™"; // &trade;
     const REG                 = "®"; // &reg;
     const COPY                = "©"; // &copy;
+    const ALL_SPACES          = '\xE2\x80\xAF|\xC2\xAD|\xC2\xA0|\s'; // All supported spaces, used in regexps. Better than \s
 
     /**
      * @var array   HTML Tags to bypass

--- a/src/JoliTypo/Fixer/Dimension.php
+++ b/src/JoliTypo/Fixer/Dimension.php
@@ -10,7 +10,7 @@ class Dimension implements FixerInterface
 {
     public function fix($content, StateBag $state_bag = null)
     {
-        $content = preg_replace('@(\d+["\']?)( ?)x\\2(?=\d)@', '$1$2'.Fixer::TIMES.'$2', $content);
+        $content = preg_replace('@(\d+["\']?)('.Fixer::ALL_SPACES.')?x('.Fixer::ALL_SPACES.')?(?=\d)@', '$1$2'.Fixer::TIMES.'$2', $content);
 
         return $content;
     }

--- a/src/JoliTypo/Fixer/Numeric.php
+++ b/src/JoliTypo/Fixer/Numeric.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace JoliTypo\Fixer;
+
+use JoliTypo\Fixer;
+use JoliTypo\FixerInterface;
+use JoliTypo\StateBag;
+
+/**
+ * Add nbsp between numeric and units.
+ */
+class Numeric implements FixerInterface
+{
+    public function fix($content, StateBag $state_bag = null)
+    {
+        // Support a wide range of currencies
+        $content = preg_replace('@([\dº])( +)([º°%฿₵¢₡$₫֏€ƒ₲₴₭£₤₺₦₨₱៛₹$₪৳₸₮₩¥\w]{1})@', '$1'.Fixer::NO_BREAK_SPACE.'$3', $content);
+
+        return $content;
+    }
+}

--- a/src/JoliTypo/Fixer/Numeric.php
+++ b/src/JoliTypo/Fixer/Numeric.php
@@ -14,7 +14,7 @@ class Numeric implements FixerInterface
     public function fix($content, StateBag $state_bag = null)
     {
         // Support a wide range of currencies
-        $content = preg_replace('@([\dº])( +)([º°%฿₵¢₡$₫֏€ƒ₲₴₭£₤₺₦₨₱៛₹$₪৳₸₮₩¥\w]{1})@', '$1'.Fixer::NO_BREAK_SPACE.'$3', $content);
+        $content = preg_replace('@([\dº])( +)([º°%Ω฿₵¢₡$₫֏€ƒ₲₴₭£₤₺₦₨₱៛₹$₪৳₸₮₩¥\w]{1})@', '$1'.Fixer::NO_BREAK_SPACE.'$3', $content);
 
         return $content;
     }

--- a/tests/JoliTypo/Tests/EnglishTest.php
+++ b/tests/JoliTypo/Tests/EnglishTest.php
@@ -5,7 +5,7 @@ use JoliTypo\Fixer;
 
 class EnglishTest extends \PHPUnit_Framework_TestCase
 {
-    private $en_fixers = array('Ellipsis', 'Dimension', 'Dash', 'EnglishQuotes', 'CurlyQuote', 'Hyphen', 'Trademark');
+    private $en_fixers = array('Numeric', 'Ellipsis', 'Dimension', 'Dash', 'EnglishQuotes', 'CurlyQuote', 'Hyphen', 'Trademark');
 
     const TOFIX = <<<TOFIX
 <!-- From https://en.wikipedia.org/wiki/Gif#Pronunciation -->
@@ -72,7 +72,7 @@ HTML;
     public function testHtmlHeart()
     {
         $fixed = <<<HTML
-<p>We &lt;3 web.</p>
+<p>We &lt;3&nbsp;web.</p>
 HTML;
 
         $to_fix = <<<HTML

--- a/tests/JoliTypo/Tests/Fixer/NumericTest.php
+++ b/tests/JoliTypo/Tests/Fixer/NumericTest.php
@@ -23,5 +23,6 @@ class NumericTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("10e position", $fixer->fix("10e position")); // We can't fix this reliably
         $this->assertEquals("nº".Fixer::NO_BREAK_SPACE."11", $fixer->fix("nº 11"));
         $this->assertEquals("12".Fixer::NO_BREAK_SPACE."%", $fixer->fix("12 %"));
+        $this->assertEquals("13".Fixer::NO_BREAK_SPACE."Ω", $fixer->fix("13 Ω"));
     }
 }

--- a/tests/JoliTypo/Tests/Fixer/NumericTest.php
+++ b/tests/JoliTypo/Tests/Fixer/NumericTest.php
@@ -1,0 +1,27 @@
+<?php
+namespace JoliTypo\Tests\Fixer;
+
+use JoliTypo\Fixer;
+
+class NumericTest extends \PHPUnit_Framework_TestCase
+{
+    public function testNumericUnits()
+    {
+        $fixer = new Fixer\Numeric();
+        $this->assertInstanceOf('JoliTypo\Fixer\Numeric', $fixer);
+
+        $this->assertEquals("Test", $fixer->fix("Test"));
+        $this->assertEquals("1".Fixer::NO_BREAK_SPACE."h", $fixer->fix("1 h"));
+        $this->assertEquals("2".Fixer::NO_BREAK_SPACE."฿", $fixer->fix("2 ฿"));
+        $this->assertEquals("3".Fixer::NO_BREAK_SPACE."things", $fixer->fix("3 things"));
+        $this->assertEquals("4,5".Fixer::NO_BREAK_SPACE."km", $fixer->fix("4,5 km"));
+        $this->assertEquals("5.1".Fixer::NO_BREAK_SPACE."deg", $fixer->fix("5.1 deg"));
+        $this->assertEquals("6".Fixer::NO_BREAK_SPACE."ºC", $fixer->fix("6 ºC"));
+        $this->assertEquals("7".Fixer::NO_BREAK_SPACE."$", $fixer->fix("7 $"));
+        $this->assertEquals("8º".Fixer::NO_BREAK_SPACE."18′ 30″", $fixer->fix("8º 18′ 30″"));
+        $this->assertEquals("9".Fixer::NO_BREAK_SPACE."hours", $fixer->fix("9 hours"));
+        $this->assertEquals("10e position", $fixer->fix("10e position")); // We can't fix this reliably
+        $this->assertEquals("nº".Fixer::NO_BREAK_SPACE."11", $fixer->fix("nº 11"));
+        $this->assertEquals("12".Fixer::NO_BREAK_SPACE."%", $fixer->fix("12 %"));
+    }
+}

--- a/tests/JoliTypo/Tests/FrenchTest.php
+++ b/tests/JoliTypo/Tests/FrenchTest.php
@@ -5,7 +5,7 @@ use JoliTypo\Fixer;
 
 class FrenchTest extends \PHPUnit_Framework_TestCase
 {
-    private $fr_fixers = array('Ellipsis', 'Dimension', 'Dash', 'FrenchQuotes', 'FrenchNoBreakSpace', 'CurlyQuote', 'Hyphen', 'Trademark');
+    private $fr_fixers = array('Numeric', 'Ellipsis', 'Dimension', 'Dash', 'FrenchQuotes', 'FrenchNoBreakSpace', 'CurlyQuote', 'Hyphen', 'Trademark');
 
     const TOFIX = <<<TOFIX
 <p>Ceci est à remplacer par une fâble :p</p>
@@ -22,7 +22,7 @@ content" de t'avoir <a href="http://coucou">invité</a> !</p>
   pre
 </code></pre>
 
-<p>Ceci &eacute;té un "CHOQUE"&nbsp;! Son salon fait 4x4m, ce qui est plutôt petit.</p>
+<p>Ceci &eacute;té un "CHOQUE"&nbsp;! Son salon fait 4x4 m, ce qui est plutôt petit.</p>
 
 <p>Les trés long mots sont tronqués, comme "renseignements" par exemple.</p>
 
@@ -46,7 +46,7 @@ content&nbsp;&raquo; de t&rsquo;avoir <a href="http://coucou">invit&eacute;</a>&
   pre
 </code></pre>
 
-<p>Ceci &eacute;t&eacute; un &laquo;&nbsp;CHOQUE&nbsp;&raquo;&#8239;! Son salon fait 4&times;4m, ce qui est plut&ocirc;t petit.</p>
+<p>Ceci &eacute;t&eacute; un &laquo;&nbsp;CHOQUE&nbsp;&raquo;&#8239;! Son salon fait 4&times;4&nbsp;m, ce qui est plut&ocirc;t petit.</p>
 
 <p>Les tr&eacute;s long mots sont tronqu&eacute;s, comme &laquo;&nbsp;rensei&shy;gne&shy;ments&nbsp;&raquo; par exemple.</p>
 
@@ -81,7 +81,7 @@ FIXED;
 
         $fixed = <<<HTML
 <p>A la sauce &laquo;&nbsp;<a href="http://composer.json.jolicode.com">compo&shy;ser.json</a>&nbsp;&raquo;
- atti&shy;rera forc&eacute;&shy;ment plus notre atten&shy;tion qu&rsquo;une lettre de moti&shy;va&shy;tion de 4 pages en &laquo;&nbsp;.docx&nbsp;&raquo;</p>
+ atti&shy;rera forc&eacute;&shy;ment plus notre atten&shy;tion qu&rsquo;une lettre de moti&shy;va&shy;tion de 4&nbsp;pages en &laquo;&nbsp;.docx&nbsp;&raquo;</p>
 HTML;
 
         $to_fix = <<<HTML
@@ -131,6 +131,27 @@ HTML;
 
         $to_fix = <<<HTML
 &laquo; test &raquo; et &laquo;test&raquo; sont dans un bateau.
+HTML;
+
+        $this->assertEquals($fixed, $fixer->fix($to_fix));
+    }
+
+    /**
+     * @see https://github.com/jolicode/JoliTypo/issues/15
+     */
+    public function testNumericDoesNotBreakOtherFixers()
+    {
+        $fixer = new Fixer($this->fr_fixers);
+
+        $fixer->setLocale('fr');
+        $this->assertInstanceOf('JoliTypo\Fixer', $fixer);
+
+        $fixed = <<<HTML
+2&nbsp;&times;&nbsp;5&nbsp;doit &ecirc;tre corrig&eacute;, et 2&nbsp;h aussi.
+HTML;
+
+        $to_fix = <<<HTML
+2 x 5 doit être corrigé, et 2 h aussi.
 HTML;
 
         $this->assertEquals($fixed, $fixer->fix($to_fix));


### PR DESCRIPTION
Here is my take at #15, because I can't merge #19 due to license issues :disappointed: 

This proposal is simpler, it handle the vast majority of cases I found,
with some exceptions / limitations:

- no transformation for `10e position`;
- only tranform the first part in `8º 18′ 30″` => `8º_18′ 30″`

fix #15.