### PR TITLE
Deprecate English/French/German smart quoters, introduce SmartQuote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
 * PSR2 and Symfony coding standard applied everywhere
 * add `fixString` method to bypass the DomDocument parsing and directly run the fixers on a string
 * better handling of common spaces in texts to fix (do not use `\s` anymore)
+* :warning: replace `EnglishQuotes`, `FrenchQuotes`, `GermanQuotes` by the new `SmartQuotes`! A BC layer is provided.
 
 ### 0.2.0 (2015-07-13) ###
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ JoliTypo is a tool fixing [Microtypography](https://en.wikipedia.org/wiki/Microt
 ```php
 use JoliTypo\Fixer;
 
-$fixer = new Fixer(array('Ellipsis', 'Dash', 'EnglishQuotes', 'CurlyQuote', 'Hyphen'));
+$fixer = new Fixer(array('Ellipsis', 'Dash', 'SmartQuotes', 'CurlyQuote', 'Hyphen'));
 $fixed_content = $fixer->fix('<p>"Tell me Mr. Anderson... what good is a phone call... if you\'re unable to speak?" -- Agent Smith, <em>Matrix</em>.</p>');
 ```
 ```html
@@ -40,7 +40,8 @@ Just tell the Fixer class [which Fixer](#available-fixers) you want to run on yo
 ```php
 use JoliTypo\Fixer;
 
-$fixer = new Fixer(array("FrenchQuotes", "FrenchNoBreakSpace"));
+$fixer = new Fixer(array("SmartQuotes", "FrenchNoBreakSpace"));
+$fixer->setLocale('fr_FR');
 $fixed_content = $fixer->fix('<p>Je suis "très content" de t\'avoir invité sur <a href="http://jolicode.com/">Jolicode.com</a> !</p>');
 ```
 
@@ -55,7 +56,7 @@ To fix non HTML content, use the `fixString()` method:
 ```php
 use JoliTypo\Fixer;
 
-$fixer = new Fixer(array("Trademark", "EnglishQuotes"));
+$fixer = new Fixer(array("Trademark", "SmartQuotes"));
 $fixed_content = $fixer->fixString('Here is a "protip(c)"!'); // Here is a “protip©”!
 ```
 
@@ -95,21 +96,16 @@ Ellipsis
 
 Replace the three dot `...` by an ellipsis `…`.
 
-EnglishQuotes
--------------
+SmartQuotes
+-----------
 
-Convert dumb quotes `" "` to smart English style quotation marks `“ ”`.
+Convert dumb quotes `" "` to all kind of smart style quotation marks (`“ ”`, `« »`, `„ “`...). Handle a good variety of locales,
+like English, Arabic, French, Italian, Spanish, Irish, German...
 
-FrenchQuotes
-------------
+See [the code](https://github.com/jolicode/JoliTypo/blob/master/src/JoliTypo/Fixer/SmartQuotes.php) for more details, 
+and do not forget to specify a locale on the Fixer instance.
 
-Convert dumb quotes `" "` to smart French style quotation marks `« »` and use a no break space.
-
-GermanQuotes
-------------
-
-Convert dumb quotes `" "` to smart German style quotation marks `„ “` (Anführungszeichen).
-Some fonts (Verdana) are typographically incompatible with German.
+This Fixer replace legacy `EnglishQuotes`, `FrenchQuotes` and `GermanQuotes`.
 
 FrenchNoBreakSpace
 ------------------
@@ -163,8 +159,8 @@ en_GB
 -----
 
 ```php
-$fixer = new Fixer(array('Ellipsis', 'Dimension', 'Numeric', 'Dash', 'EnglishQuotes', 'NoSpaceBeforeComma', 'CurlyQuote', 'Hyphen', 'Trademark'));
-$fixer->setLocale('en_GB'); // Needed by the Hyphen Fixer
+$fixer = new Fixer(array('Ellipsis', 'Dimension', 'Numeric', 'Dash', 'SmartQuotes', 'NoSpaceBeforeComma', 'CurlyQuote', 'Hyphen', 'Trademark'));
+$fixer->setLocale('en_GB');
 ```
 
 fr_FR
@@ -173,8 +169,8 @@ fr_FR
 Those rules apply most of the recommendations of "Abrégé du code typographique à l'usage de la presse", ISBN: 9782351130667.
 
 ```php
-$fixer = new Fixer(array('Ellipsis', 'Dimension', 'Numeric', 'Dash', 'FrenchQuotes', 'FrenchNoBreakSpace', 'NoSpaceBeforeComma', 'CurlyQuote', 'Hyphen', 'Trademark'));
-$fixer->setLocale('fr_FR'); // Needed by the Hyphen Fixer
+$fixer = new Fixer(array('Ellipsis', 'Dimension', 'Numeric', 'Dash', 'SmartQuotes', 'FrenchNoBreakSpace', 'NoSpaceBeforeComma', 'CurlyQuote', 'Hyphen', 'Trademark'));
+$fixer->setLocale('fr_FR');
 ```
 
 fr_CA
@@ -183,8 +179,8 @@ fr_CA
 Mostly the same as fr_FR, but the space before punctuation points is not mandatory.
 
 ```php
-$fixer = new Fixer(array('Ellipsis', 'Dimension', 'Numeric', 'Dash', 'FrenchQuotes', 'NoSpaceBeforeComma', 'CurlyQuote', 'Hyphen', 'Trademark'));
-$fixer->setLocale('fr_CA'); // Needed by the Hyphen Fixer
+$fixer = new Fixer(array('Ellipsis', 'Dimension', 'Numeric', 'Dash', 'SmartQuotes', 'NoSpaceBeforeComma', 'CurlyQuote', 'Hyphen', 'Trademark'));
+$fixer->setLocale('fr_CA');
 ```
 
 de_DE
@@ -193,8 +189,8 @@ de_DE
 Mostly the same as en_GB, according to [Typefacts](http://typefacts.com/) and [Wikipedia](http://de.wikipedia.org/wiki/Typografie_f%C3%BCr_digitale_Texte).
 
 ```php
-$fixer = new Fixer(array('Ellipsis', 'Dimension', 'Numeric', 'Dash', 'GermanQuotes', 'NoSpaceBeforeComma', 'CurlyQuote', 'Hyphen', 'Trademark'));
-$fixer->setLocale('de_DE'); // Needed by the Hyphen Fixer
+$fixer = new Fixer(array('Ellipsis', 'Dimension', 'Numeric', 'Dash', 'SmartQuotes', 'NoSpaceBeforeComma', 'CurlyQuote', 'Hyphen', 'Trademark'));
+$fixer->setLocale('de_DE');
 ```
 
 More to come (contributions welcome!).
@@ -207,14 +203,14 @@ Default usage
 -------------
 
 ```php
-$fixer          = new Fixer(array('Ellipsis', 'Dimension', 'Dash', 'EnglishQuotes', 'CurlyQuote', 'Hyphen'));
+$fixer          = new Fixer(array('Ellipsis', 'Dimension', 'Dash', 'SmartQuotes', 'CurlyQuote', 'Hyphen'));
 $fixed_content  = $fixer->fix("<p>Some user contributed HTML which does not use proper glyphs.</p>");
 
 $fixer->setRules(array('CurlyQuote'));
 $fixed_content = $fixer->fix("<p>I'm only replacing single quotes.</p>");
 
 $fixer->setRules(array('Hyphen'));
-$fixer->setLocale('en_GB'); // I tell which locale to use for Hyphenation
+$fixer->setLocale('en_GB'); // I tell which locale to use for Hyphenation and SmartQuotes
 $fixed_content = $fixer->fix("<p>Very long words like Antidisestablishmentarianism.</p>");
 ```
 

--- a/src/JoliTypo/Exception/BadFixerConfigurationException.php
+++ b/src/JoliTypo/Exception/BadFixerConfigurationException.php
@@ -7,12 +7,9 @@
  * and is licensed under the MIT license.
  */
 
-namespace JoliTypo;
+namespace JoliTypo\Exception;
 
-interface LocaleAwareFixerInterface
+class BadFixerConfigurationException extends \Exception
 {
-    /**
-     * @param string $locale
-     */
-    public function setLocale($locale);
+    protected $message = 'Fixer needs configuration.';
 }

--- a/src/JoliTypo/Fixer/EnglishQuotes.php
+++ b/src/JoliTypo/Fixer/EnglishQuotes.php
@@ -9,28 +9,13 @@
 
 namespace JoliTypo\Fixer;
 
-use JoliTypo\Fixer;
-use JoliTypo\FixerInterface;
-use JoliTypo\StateBag;
-
 /**
- * Convert dumb quotes (" ") to smart quotes (“ ”).
+ * @deprecated Use SmartQuotes, to be removed in 2.0
  */
-class EnglishQuotes extends BaseOpenClosePair implements FixerInterface
+class EnglishQuotes extends SmartQuotes
 {
-    public function fix($content, StateBag $stateBag = null)
+    public function __construct($locale = null)
     {
-        // Fix complex siblings cases
-        if ($stateBag) {
-            $content = $this->fixViaState($content, $stateBag, 'EnglishQuotesOpenSolo',
-                '@(^|\s|\()"([^"]*)$@', '@(^|[^"]+)"@im', Fixer::LDQUO, Fixer::RDQUO);
-        }
-
-        $content = preg_replace(
-                    '@(^|\s|\()"([^"]+)"@im',
-                    '$1'.Fixer::LDQUO.'$2'.Fixer::RDQUO,
-                    $content);
-
-        return $content;
+        parent::__construct('en');
     }
 }

--- a/src/JoliTypo/Fixer/FrenchQuotes.php
+++ b/src/JoliTypo/Fixer/FrenchQuotes.php
@@ -9,30 +9,13 @@
 
 namespace JoliTypo\Fixer;
 
-use JoliTypo\Fixer;
-use JoliTypo\FixerInterface;
-use JoliTypo\StateBag;
-
 /**
- * Use NO_BREAK_SPACE between the « » and the text as
- * recommended by "Abrégé du code typographique à l'usage de la presse", ISBN: 978-2351130667.
+ * @deprecated Use SmartQuotes, to be removed in 2.0
  */
-class FrenchQuotes extends BaseOpenClosePair implements FixerInterface
+class FrenchQuotes extends SmartQuotes
 {
-    public function fix($content, StateBag $stateBag = null)
+    public function __construct($locale = null)
     {
-        // Fix complex siblings cases
-        if ($stateBag) {
-            $content = $this->fixViaState($content, $stateBag, 'FrenchQuotesOpenSolo',
-                '@(^|\s|\()"([^"]*)$@im', '@(^|[^"]+)"@im', Fixer::LAQUO.Fixer::NO_BREAK_SPACE,
-                    Fixer::NO_BREAK_SPACE.Fixer::RAQUO);
-        }
-
-        // Fix simple cases
-        $content = preg_replace('@(^|\s|\()"([^"]+)"@im',
-            '$1'.Fixer::LAQUO.Fixer::NO_BREAK_SPACE.'$2'.Fixer::NO_BREAK_SPACE.Fixer::RAQUO,
-            $content);
-
-        return $content;
+        parent::__construct('fr');
     }
 }

--- a/src/JoliTypo/Fixer/GermanQuotes.php
+++ b/src/JoliTypo/Fixer/GermanQuotes.php
@@ -9,28 +9,13 @@
 
 namespace JoliTypo\Fixer;
 
-use JoliTypo\Fixer;
-use JoliTypo\FixerInterface;
-use JoliTypo\StateBag;
-
 /**
- * Convert dumb quotes (" ") to smart quotes („ “).
+ * @deprecated Use SmartQuotes, to be removed in 2.0
  */
-class GermanQuotes extends BaseOpenClosePair implements FixerInterface
+class GermanQuotes extends SmartQuotes
 {
-    public function fix($content, StateBag $stateBag = null)
+    public function __construct($locale = null)
     {
-        // Fix complex siblings cases
-        if ($stateBag) {
-            $content = $this->fixViaState($content, $stateBag, 'GermanQuotesOpenSolo',
-                '@(^|\s|\()"([^"]*)$@', '@(^|[^"]+)"@im', Fixer::BDQUO, Fixer::LDQUO);
-        }
-
-        $content = preg_replace(
-                    '@(^|\s|\()"([^"]+)"@im',
-                    '$1'.Fixer::BDQUO.'$2'.Fixer::LDQUO,
-                    $content);
-
-        return $content;
+        parent::__construct('de');
     }
 }

--- a/src/JoliTypo/Fixer/Hyphen.php
+++ b/src/JoliTypo/Fixer/Hyphen.php
@@ -31,8 +31,7 @@ class Hyphen implements FixerInterface, LocaleAwareFixerInterface
 
     public function __construct($locale)
     {
-        $this->hyphenator = Hyphenator::factory(null, $this->fixLocale($locale));
-        $this->setOptions();
+        $this->setLocale($locale);
     }
 
     /**

--- a/src/JoliTypo/Fixer/SmartQuotes.php
+++ b/src/JoliTypo/Fixer/SmartQuotes.php
@@ -1,0 +1,181 @@
+<?php
+
+/*
+ * This file is part of JoliTypo - a project by JoliCode.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ */
+
+namespace JoliTypo\Fixer;
+
+use JoliTypo\Exception\BadFixerConfigurationException;
+use JoliTypo\Fixer;
+use JoliTypo\FixerInterface;
+use JoliTypo\LocaleAwareFixerInterface;
+use JoliTypo\StateBag;
+
+class SmartQuotes extends BaseOpenClosePair implements FixerInterface, LocaleAwareFixerInterface
+{
+    protected $opening;
+    protected $openingSuffix = '';
+    protected $closing;
+    protected $closingPrefix = '';
+
+    public function __construct($locale)
+    {
+        $this->setLocale($locale);
+    }
+
+    public function fix($content, StateBag $stateBag = null)
+    {
+        if (!$this->opening || !$this->closing) {
+            throw new BadFixerConfigurationException();
+        }
+
+        // Fix complex siblings cases
+        if ($stateBag) {
+            $content = $this->fixViaState($content, $stateBag, 'SmartQuotesOpenSolo',
+                    '@(^|\s|\()"([^"]*)$@im', '@(^|[^"]+)"@im', $this->opening.$this->openingSuffix,
+                    $this->closingPrefix.$this->closing);
+        }
+
+        // Fix simple cases
+        $content = preg_replace('@(^|\s|\()"([^"]+)"@im',
+                '$1'.$this->opening.$this->openingSuffix.'$2'.$this->closingPrefix.$this->closing,
+                $content);
+
+        return $content;
+    }
+
+    /**
+     * Default configuration for supported lang.
+     *
+     * @param string $locale
+     */
+    public function setLocale($locale)
+    {
+        // Handle from locale + country
+        switch (strtolower($locale)) {
+            // “…”
+            case 'pt-br':
+                $this->opening = Fixer::LDQUO;
+                $this->openingSuffix = '';
+                $this->closing = Fixer::RDQUO;
+                $this->closingPrefix = '';
+
+                return;
+        }
+
+        // Handle from locale only
+        $short = Fixer::getLanguageFromLocale($locale);
+
+        switch ($short) {
+            // « … »
+            case 'fr':
+                $this->opening = Fixer::LAQUO;
+                $this->openingSuffix = Fixer::NO_BREAK_SPACE;
+                $this->closing = Fixer::RAQUO;
+                $this->closingPrefix = Fixer::NO_BREAK_SPACE;
+                break;
+            // «…»
+            case 'hy':
+            case 'az':
+            case 'hz':
+            case 'eu':
+            case 'be':
+            case 'ca':
+            case 'el':
+            case 'it':
+            case 'no':
+            case 'fa':
+            case 'lv':
+            case 'pt':
+            case 'ru':
+            case 'es':
+            case 'uk':
+                $this->opening = Fixer::LAQUO;
+                $this->openingSuffix = '';
+                $this->closing = Fixer::RAQUO;
+                $this->closingPrefix = '';
+                break;
+            // „…“
+            case 'de':
+            case 'ka':
+            case 'cs':
+            case 'et':
+            case 'is':
+            case 'lt':
+            case 'mk':
+            case 'ro':
+            case 'sk':
+            case 'sl':
+            case 'wen':
+                $this->opening = Fixer::BDQUO;
+                $this->openingSuffix = '';
+                $this->closing = Fixer::LDQUO;
+                $this->closingPrefix = '';
+                break;
+            // “…”
+            case 'en':
+            case 'us':
+            case 'gb':
+            case 'af':
+            case 'ar':
+            case 'eo':
+            case 'id':
+            case 'ga':
+            case 'ko':
+            case 'br':
+            case 'th':
+            case 'tr':
+            case 'vi':
+                $this->opening = Fixer::LDQUO;
+                $this->openingSuffix = '';
+                $this->closing = Fixer::RDQUO;
+                $this->closingPrefix = '';
+                break;
+            // ”…”
+            case 'fi':
+            case 'sv':
+            case 'bs':
+                $this->opening = Fixer::RDQUO;
+                $this->openingSuffix = '';
+                $this->closing = Fixer::RDQUO;
+                $this->closingPrefix = '';
+                break;
+        }
+    }
+
+    /**
+     * @param string $opening
+     */
+    public function setOpening($opening)
+    {
+        $this->opening = $opening;
+    }
+
+    /**
+     * @param string $openingSuffix
+     */
+    public function setOpeningSuffix($openingSuffix)
+    {
+        $this->openingSuffix = $openingSuffix;
+    }
+
+    /**
+     * @param string $closing
+     */
+    public function setClosing($closing)
+    {
+        $this->closing = $closing;
+    }
+
+    /**
+     * @param string $closingPrefix
+     */
+    public function setClosingPrefix($closingPrefix)
+    {
+        $this->closingPrefix = $closingPrefix;
+    }
+}

--- a/tests/JoliTypo/Tests/EnglishTest.php
+++ b/tests/JoliTypo/Tests/EnglishTest.php
@@ -13,7 +13,7 @@ use JoliTypo\Fixer;
 
 class EnglishTest extends \PHPUnit_Framework_TestCase
 {
-    private $en_fixers = array('Numeric', 'Ellipsis', 'Dimension', 'Dash', 'EnglishQuotes', 'CurlyQuote', 'Hyphen', 'Trademark');
+    private $en_fixers = array('Numeric', 'Ellipsis', 'Dimension', 'Dash', 'SmartQuotes', 'CurlyQuote', 'Hyphen', 'Trademark');
 
     const TOFIX = <<<TOFIX
 <!-- From https://en.wikipedia.org/wiki/Gif#Pronunciation -->

--- a/tests/JoliTypo/Tests/Fixer/EnglishQuotesTest.php
+++ b/tests/JoliTypo/Tests/Fixer/EnglishQuotesTest.php
@@ -18,6 +18,18 @@ class EnglishQuotesTest extends \PHPUnit_Framework_TestCase
         $fixer = new Fixer\EnglishQuotes();
         $this->assertInstanceOf('JoliTypo\Fixer\EnglishQuotes', $fixer);
 
+        $this->basicStringsAsserts($fixer);
+    }
+
+    public function testSmartQuoteConfig()
+    {
+        $fixer = new Fixer\SmartQuotes('en');
+
+        $this->basicStringsAsserts($fixer);
+    }
+
+    protected function basicStringsAsserts($fixer)
+    {
         $this->assertEquals('“I am smart”', $fixer->fix('"I am smart"'));
         $this->assertEquals('Quote say: “I am smart”', $fixer->fix('Quote say: "I am smart"'));
         $this->assertEquals("I'm not a “QUOTE”. Or a “US QUOTE.”", $fixer->fix('I\'m not a "QUOTE". Or a "US QUOTE."'));

--- a/tests/JoliTypo/Tests/Fixer/FrenchQuotesTest.php
+++ b/tests/JoliTypo/Tests/Fixer/FrenchQuotesTest.php
@@ -18,6 +18,17 @@ class FrenchQuotesTest extends \PHPUnit_Framework_TestCase
         $fixer = new Fixer\FrenchQuotes();
         $this->assertInstanceOf('JoliTypo\Fixer\FrenchQuotes', $fixer);
 
+        $this->basicStringsAsserts($fixer);
+    }
+
+    public function testSmartQuoteFrenchConfig()
+    {
+        $fixer = new Fixer\SmartQuotes('fr_FR');
+        $this->basicStringsAsserts($fixer);
+    }
+
+    protected function basicStringsAsserts($fixer)
+    {
         $this->assertEquals('«'.Fixer::NO_BREAK_SPACE.'Good code is like a good joke.'.Fixer::NO_BREAK_SPACE.'»', $fixer->fix('"Good code is like a good joke."'));
         $this->assertEquals('«'.Fixer::NO_BREAK_SPACE.'Good code is like a Bieber.'.Fixer::NO_BREAK_SPACE.'» - said no ever, ever.', $fixer->fix('"Good code is like a Bieber." - said no ever, ever.'));
 

--- a/tests/JoliTypo/Tests/Fixer/GermanQuotesTest.php
+++ b/tests/JoliTypo/Tests/Fixer/GermanQuotesTest.php
@@ -18,6 +18,18 @@ class GermanQuotesTest extends \PHPUnit_Framework_TestCase
         $fixer = new Fixer\GermanQuotes();
         $this->assertInstanceOf('JoliTypo\Fixer\GermanQuotes', $fixer);
 
+        $this->basicStringsAsserts($fixer);
+    }
+
+    public function testSmartQuoteConfig()
+    {
+        $fixer = new Fixer\SmartQuotes('de');
+
+        $this->basicStringsAsserts($fixer);
+    }
+
+    protected function basicStringsAsserts($fixer)
+    {
         $this->assertEquals('„I am smart“', $fixer->fix('"I am smart"'));
         $this->assertEquals('(„I am smart“)', $fixer->fix('("I am smart")'));
         $this->assertEquals("Andreas fragte mich: „Hast du den Artikel 'EU-Erweiterung' gelesen?“", $fixer->fix('Andreas fragte mich: "Hast du den Artikel \'EU-Erweiterung\' gelesen?"'));

--- a/tests/JoliTypo/Tests/Fixer/SmartQuotesTest.php
+++ b/tests/JoliTypo/Tests/Fixer/SmartQuotesTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of JoliTypo - a project by JoliCode.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ */
+
+namespace JoliTypo\Tests\Fixer;
+
+use JoliTypo\Fixer;
+
+class SmartQuotesTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSimpleString()
+    {
+        $fixer = new Fixer\SmartQuotes('de');
+        $this->assertInstanceOf('JoliTypo\Fixer\SmartQuotes', $fixer);
+
+        $this->assertEquals('„I am smart“', $fixer->fix('"I am smart"'));
+
+        $fixer->setOpening('«');
+        $fixer->setClosing('»');
+
+        $this->assertEquals('«I am smart»', $fixer->fix('"I am smart"'));
+
+        $fixer->setOpening('<');
+        $fixer->setClosing('>');
+
+        $this->assertEquals('<I am smart>', $fixer->fix('"I am smart"'));
+    }
+
+    /**
+     * @expectedException \JoliTypo\Exception\BadFixerConfigurationException
+     */
+    public function testBadConfig()
+    {
+        $fixer = new Fixer\SmartQuotes('unknown');
+        $fixer->fix("nope");
+    }
+}

--- a/tests/JoliTypo/Tests/FrenchTest.php
+++ b/tests/JoliTypo/Tests/FrenchTest.php
@@ -13,7 +13,7 @@ use JoliTypo\Fixer;
 
 class FrenchTest extends \PHPUnit_Framework_TestCase
 {
-    private $fr_fixers = array('Numeric', 'Ellipsis', 'Dimension', 'Dash', 'FrenchQuotes', 'FrenchNoBreakSpace', 'CurlyQuote', 'Hyphen', 'Trademark');
+    private $fr_fixers = array('Numeric', 'Ellipsis', 'Dimension', 'Dash', 'SmartQuotes', 'FrenchNoBreakSpace', 'CurlyQuote', 'Hyphen', 'Trademark');
 
     const TOFIX = <<<TOFIX
 <p>Ceci est à remplacer par une fâble :p</p>

--- a/tests/JoliTypo/Tests/JoliTypoTest.php
+++ b/tests/JoliTypo/Tests/JoliTypoTest.php
@@ -162,7 +162,7 @@ class JoliTypoTest extends \PHPUnit_Framework_TestCase
 
     public function testNonHTMLContent()
     {
-        $fixer = new Fixer(array('Trademark', 'EnglishQuotes'));
+        $fixer = new Fixer(array('Trademark', 'SmartQuotes'));
         $this->assertInstanceOf('JoliTypo\Fixer', $fixer);
 
         $toFix = <<<NOT_HTML


### PR DESCRIPTION
Fix #10.

The way smart quotes were fixed wasn't good, there is a LOT of different quotation marks and we needed a way to make the fixer configurable.

Based on https://en.wikipedia.org/wiki/Quotation_mark, SmartQuotes fixer is now able to auto-configure opening and closing quotes for a lot of languages.

SmartQuotes is smart :smile: 