### PR TITLE
Add built-in support for Symfony and Twig

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ composer require jolicode/jolitypo
 Integrations
 ===========
 
-- (Official) [Symfony2 Bundle and twig extension](https://github.com/jolicode/JoliTypoBundle)
+- (Built-in) [Symfony Bundle](src/JoliTypo/Bridge/Symfony)
+- (Built-in) [Twig extension](src/JoliTypo/Bridge/Twig)
 - [Wordpress plugin](http://wordpress.org/plugins/typofr/)
 - [Drupal module](https://github.com/Anaethelion/JoliTypo-for-Drupal)
 

--- a/TODO.md
+++ b/TODO.md
@@ -47,3 +47,12 @@ en-GB
 -----
 
 - [x] Make sure all the rules described [here](http://practicaltypography.com/summary-of-key-rules.html) are respected;
+
+Bridge
+======
+
+Symfony
+-------
+
+- Allow to set service as Fixer via an `@`
+- Use Lazy services for all the presets

--- a/composer.json
+++ b/composer.json
@@ -18,17 +18,17 @@
         "lib-libxml": "*",
         "org_heigl/hyphenator": "~2.0.3"
     },
+    "require-dev": {
+        "friendsofphp/php-cs-fixer": "~2.2.0",
+        "phpunit/phpunit": "~4.5",
+        "symfony/framework-bundle": "^2.3|^3.0|^4.0"
+    },
     "conflict": {
         "ext-apc": "3.1.11"
     },
     "autoload": {
-        "psr-0": {
-            "JoliTypo": "src/"
-        }
-    },
-    "require-dev": {
-        "friendsofphp/php-cs-fixer": "~2.2.0",
-        "phpunit/phpunit": "~4.5"
+        "psr-0": { "JoliTypo": "src/" },
+        "psr-4": { "JoliTypo\\": "" }
     },
     "scripts": {
         "test": "vendor/bin/phpunit -c phpunit.xml.dist",

--- a/src/JoliTypo/Bridge/Symfony/DependencyInjection/Configuration.php
+++ b/src/JoliTypo/Bridge/Symfony/DependencyInjection/Configuration.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace JoliTypo\Bridge\Symfony\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class Configuration implements ConfigurationInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('joli_typo');
+
+        $rootNode
+            ->fixXmlConfig('preset')
+            ->children()
+                ->arrayNode('presets')
+                    ->useAttributeAsKey('name')
+                    ->isRequired()
+                    ->prototype('array')
+                        ->children()
+                            ->scalarNode('locale')->end()
+                            ->arrayNode('fixers')
+                                ->prototype('scalar')
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+
+        return $treeBuilder;
+    }
+}

--- a/src/JoliTypo/Bridge/Symfony/DependencyInjection/JoliTypoExtension.php
+++ b/src/JoliTypo/Bridge/Symfony/DependencyInjection/JoliTypoExtension.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace JoliTypo\Bridge\Symfony\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+
+class JoliTypoExtension extends Extension
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $configuration = new Configuration();
+        $config = $this->processConfiguration($configuration, $configs);
+        $presets = $this->createPresetDefinition($container, $config);
+
+        // Twig extension
+        $twig_extension = new Definition('JoliTypo\Bridge\Twig\JoliTypoExtension');
+        $twig_extension->addTag('twig.extension');
+        $twig_extension->setArguments(array($presets));
+
+        $container->setDefinition('joli_typo.twig_extension', $twig_extension);
+    }
+
+    private function createPresetDefinition(ContainerBuilder $container, $config)
+    {
+        $presets = array();
+
+        foreach ($config['presets'] as $name => $preset) {
+            $definition = new Definition('JoliTypo\Fixer');
+
+            if ($preset['locale']) {
+                $definition->addMethodCall('setLocale', array($preset['locale']));
+            }
+
+            $fixers = array();
+            foreach ($preset['fixers'] as $fixer) {
+                // Allow to use services as fixer?
+                $fixers[] = $fixer;
+            }
+
+            $definition->addArgument($fixers);
+            $container->setDefinition(sprintf('joli_typo.fixer.%s', $name), $definition);
+
+            $presets[$name] = new Reference(sprintf('joli_typo.fixer.%s', $name));
+        }
+
+        return $presets;
+    }
+}

--- a/src/JoliTypo/Bridge/Symfony/JoliTypoBundle.php
+++ b/src/JoliTypo/Bridge/Symfony/JoliTypoBundle.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace JoliTypo\Bridge\Symfony;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class JoliTypoBundle extends Bundle
+{
+}

--- a/src/JoliTypo/Bridge/Symfony/README.md
+++ b/src/JoliTypo/Bridge/Symfony/README.md
@@ -1,0 +1,51 @@
+This bundle integrates the [JoliTypo](https://github.com/jolicode/JoliTypo) library into Symfony.
+
+Please refer to the [JoliTypo documentation](https://github.com/jolicode/JoliTypo/blob/master/README.md) to learn more
+about fixers and how to combine them.
+
+**Note:** there is no cache involved with JoliTypo, take care of it if you want to save some CPU cycles :grimacing:
+
+Not using Symfony Flex? Register the bundle `Joli\TypoBundle\JoliTypoBundle` in your kernel:
+
+```php
+  new Joli\TypoBundle\JoliTypoBundle(),
+```
+
+Define your Fixers preset as you want (in `config/packages/joli_typo.yaml` or `app/config/config.yml`):
+
+```yaml
+joli_typo:
+    presets:
+        fr:
+            fixers: [ Ellipsis, Dimension, Dash, SmartQuotes, FrenchNoBreakSpace, CurlyQuote, Trademark ]
+            locale: fr_FR
+        en:
+            fixers: [ Ellipsis, Dimension, Dash, SmartQuotes, CurlyQuote, Trademark ]
+            locale: en_GB
+```
+
+Twig function
+=============
+
+The Bundle makes use of the Twig bridge and it's method/filter named `jolitypo`, waiting for two arguments: HTML content
+to fix and the preset name.
+
+```twig
+{{ jolitypo('<p>Hi folk!</p>', 'fr') | raw }}
+
+{# or #}
+
+{{ '<p>Hi folk!</p>' | jolitypo('fr') }}
+```
+
+Another way to use it is by passing a whole block to it:
+
+```twig
+{% block content %}
+    {{ jolitypo(block('real_content'), 'fr') | raw }}
+{% endblock %}
+
+{% block real_content %}
+    <h2>My whole dynamic page</h2>
+{% endblock %}
+```

--- a/src/JoliTypo/Bridge/Twig/JoliTypoExtension.php
+++ b/src/JoliTypo/Bridge/Twig/JoliTypoExtension.php
@@ -1,0 +1,42 @@
+<?php
+namespace JoliTypo\Bridge\Symfony\Twig;
+
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+
+class JoliTypoExtension extends \Twig_Extension
+{
+    private $presets = array();
+
+    public function __construct($presets)
+    {
+        $this->presets = $presets;
+    }
+
+    public function getFunctions()
+    {
+        return array(
+            new \Twig_SimpleFunction('jolitypo', array($this, 'translate')),
+        );
+    }
+
+    public function getFilters()
+    {
+        return array(
+            new \Twig_SimpleFilter('jolitypo', array($this, 'translate'), array('pre_escape' => 'html', 'is_safe' => array('html'))),
+        );
+    }
+
+    public function translate($text, $preset = "default")
+    {
+        if (!isset($this->presets[$preset])) {
+            throw new InvalidConfigurationException(sprintf("There is no '%s' preset configured.", $preset));
+        }
+
+        return $this->presets[$preset]->fix($text);
+    }
+
+    public function getName()
+    {
+        return 'jolitypo';
+    }
+}


### PR DESCRIPTION
- Symfony recipe for Flex is added [here](https://github.com/symfony/recipes-contrib/pull/473)

Todo:
- [ ] Mark https://github.com/jolicode/JoliTypoBundle as deprecated (on readme and Packagist)