### PR TITLE
Fix a full DOM dump error occuring on Ubuntu PHP 7.3

### DIFF
--- a/src/JoliTypo/Fixer.php
+++ b/src/JoliTypo/Fixer.php
@@ -299,7 +299,7 @@ class Fixer
         $content = preg_replace(
             [
                 "/^\<\!DOCTYPE.*?<html>.*?<body>/si",
-                '!</body></html>$!si',
+                '!</body>\n?</html>$!si',
             ],
             '',
             $dom->saveHTML()


### PR DESCRIPTION
DOM/XML API Version => 20031129

The error is not visible on Travis but I can reproduce locally.

```
There was 1 failure:

1) JoliTypo\Tests\Html5Test::testFullPageMarkup
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'&#8220;Who Let the Dogs Out?&#8221; is a song written and originally recorded by Anslem Douglas (titled &#8220;Doggie&#8221;).'
+'&#8220;Who Let the Dogs Out?&#8221; is a song written and originally recorded by Anslem Douglas (titled &#8220;Doggie&#8221;).\n
+</body>\n
+</html>'
```

Thanks @lyrixx 