### PR TITLE
Add accessibility warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ You can read more about this fixer on [the official github repository](https://g
 
 **Proper hyphenation is mandatory in justified text** and you should avoid word breaking in titles with this line of CSS: `hyphens:none;`.
 
+⚠ Be aware that the current screen readers are unable to spell correctly the words containing `&shy;` tags. The Hyphen filter should therefore be used with caution or you might reduce your website's accessibility.
+
 CurlyQuote (Smart Quote)
 -----------------------
 


### PR DESCRIPTION
I've been warned that screen readers do not read correctly words containing `&shy;` tags (it reads each syllable separately), so I thought we should tell people in the docs.