### PR TITLE
Some maintenance work

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -17,6 +17,7 @@ jobs:
         php-versions:
           - '7.4'
           - '8.0'
+          - '8.1'
 
     steps:
       - uses: actions/checkout@v2
@@ -43,6 +44,7 @@ jobs:
         php-versions:
           - '7.4'
           - '8.0'
+          - '8.1'
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 ### 1.4.0 (not released yet) ###
 
+* Drop support for Symfony < 4.4
+* Add support for Symfony ^6.0
+
 ### 1.3.0 (2022-05-30) ###
 
 * Add PHAR generation to use the library in CLI context

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 
 * Drop support for Symfony < 4.4
 * Add support for Symfony ^6.0
+* Run tests on PHP 8.1
 
 ### 1.3.0 (2022-05-30) ###
 

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "psr-4": { "JoliTypo\\Tests\\": "tests/JoliTypo/Tests" }
     },
     "scripts": {
-        "test": "vendor/bin/simple-phpunit -c phpunit.xml.dist",
+        "test": "vendor/bin/simple-phpunit",
         "cs": "vendor/bin/php-cs-fixer fix"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,10 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.3.2",
-        "symfony/phpunit-bridge": "^5.0",
-        "symfony/framework-bundle": "^3.4.26|^4.1.12|^5.0",
-        "symfony/twig-bundle": "^3.4.26|^4.1.12|^5.0",
-        "symfony/yaml": "^3.4.26|^4.1.12|^5.0"
+        "symfony/phpunit-bridge": "^5.4.8 || ^6.0",
+        "symfony/framework-bundle": "^4.4 || ^5.0 || ^6.0",
+        "symfony/twig-bundle": "^4.4 || ^5.0 || ^6.0",
+        "symfony/yaml": "^4.4 || ^5.0 || ^6.0"
     },
     "conflict": {
         "ext-apc": "3.1.11"

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": ">=7.4",
         "ext-mbstring": "*",
         "lib-libxml": "*",
-        "org_heigl/hyphenator": "~2.6.0"
+        "org_heigl/hyphenator": "^2.6 || ^3.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.3.2",

--- a/src/JoliTypo/Fixer.php
+++ b/src/JoliTypo/Fixer.php
@@ -74,9 +74,9 @@ class Fixer
     /**
      * @param string $content HTML content to fix
      *
-     * @throws Exception\BadRuleSetException
-     *
      * @return string Fixed content
+     *
+     * @throws Exception\BadRuleSetException
      */
     public function fix($content)
     {
@@ -173,8 +173,6 @@ class Fixer
     /**
      * Get language part of a Locale string (fr_FR => fr).
      *
-     * @param $locale
-     *
      * @return string
      */
     public static function getLanguageFromLocale($locale)
@@ -190,8 +188,6 @@ class Fixer
 
     /**
      * Build the _rules array of Fixer.
-     *
-     * @param $rules
      *
      * @throws Exception\BadRuleSetException
      */
@@ -290,11 +286,9 @@ class Fixer
     }
 
     /**
-     * @param $content
+     * @return \DOMDocument
      *
      * @throws Exception\InvalidMarkupException
-     *
-     * @return \DOMDocument
      */
     private function loadDOMDocument($content)
     {
@@ -326,8 +320,6 @@ class Fixer
      * @see http://php.net/manual/en/domdocument.loadhtml.php#91513
      * @see https://github.com/jolicode/JoliTypo/issues/7
      *
-     * @param $content
-     *
      * @return string
      */
     private function fixContentEncoding($content)
@@ -342,11 +334,11 @@ class Fixer
                 $content = $hack . $content;
             }
 
-            $encoding = '';
-
+            $encoding = null;
             foreach (['UTF-8', 'ASCII', 'ISO-8859-1', 'windows-1252', 'iso-8859-15'] as $testedEncoding) {
                 if (mb_detect_encoding($content, $testedEncoding, true)) {
                     $encoding = $testedEncoding;
+
                     break;
                 }
             }

--- a/src/JoliTypo/Fixer/Hyphen.php
+++ b/src/JoliTypo/Fixer/Hyphen.php
@@ -58,9 +58,6 @@ class Hyphen implements FixerInterface, LocaleAwareFixerInterface
         $this->setLocale($locale);
     }
 
-    /**
-     * @param $locale
-     */
     public function setLocale($locale)
     {
         $this->hyphenator = Hyphenator::factory(null, $this->fixLocale($locale));
@@ -81,8 +78,6 @@ class Hyphen implements FixerInterface, LocaleAwareFixerInterface
 
     /**
      * Transform fr_FR to fr to fit the list of supported locales.
-     *
-     * @param $locale
      *
      * @return mixed
      */

--- a/src/JoliTypo/Fixer/SmartQuotes.php
+++ b/src/JoliTypo/Fixer/SmartQuotes.php
@@ -71,7 +71,7 @@ class SmartQuotes extends BaseOpenClosePair implements FixerInterface, LocaleAwa
                 $this->closingPrefix = '';
 
                 return;
-            // «…»
+                // «…»
             case 'de-ch':
                 $this->opening = Fixer::LAQUO;
                 $this->openingSuffix = '';
@@ -93,7 +93,7 @@ class SmartQuotes extends BaseOpenClosePair implements FixerInterface, LocaleAwa
                 $this->closingPrefix = Fixer::NO_BREAK_SPACE;
 
                 break;
-            // «…»
+                // «…»
             case 'hy':
             case 'az':
             case 'hz':
@@ -115,7 +115,7 @@ class SmartQuotes extends BaseOpenClosePair implements FixerInterface, LocaleAwa
                 $this->closingPrefix = '';
 
                 break;
-            // „…“
+                // „…“
             case 'de':
             case 'ka':
             case 'cs':
@@ -133,7 +133,7 @@ class SmartQuotes extends BaseOpenClosePair implements FixerInterface, LocaleAwa
                 $this->closingPrefix = '';
 
                 break;
-            // “…”
+                // “…”
             case 'en':
             case 'us':
             case 'gb':
@@ -153,7 +153,7 @@ class SmartQuotes extends BaseOpenClosePair implements FixerInterface, LocaleAwa
                 $this->closingPrefix = '';
 
                 break;
-            // ”…”
+                // ”…”
             case 'fi':
             case 'sv':
             case 'bs':

--- a/tests/JoliTypo/Tests/Bridge/app/config/config.yml
+++ b/tests/JoliTypo/Tests/Bridge/app/config/config.yml
@@ -3,6 +3,7 @@ framework:
         resource: "%kernel.project_dir%/tests/JoliTypo/Tests/Bridge/app/config/routing.yml"
         strict_requirements: ~
     secret: "ThisTokenIsEnoughSecretForOurTests"
+    http_method_override: false
 twig:
     strict_variables: '%kernel.debug%'
 

--- a/tests/JoliTypo/Tests/Fixer/DashTest.php
+++ b/tests/JoliTypo/Tests/Fixer/DashTest.php
@@ -23,7 +23,7 @@ class DashTest extends TestCase
         $this->assertEquals('M. Jackson: 1964' . Fixer::NDASH . '2009', $fixer->fix('M. Jackson: 1964-2009'));
         $this->assertEquals('M. Jackson: 1964 ' . Fixer::NDASH . ' 2009', $fixer->fix('M. Jackson: 1964 - 2009'));
         $this->assertEquals('Style ' . Fixer::NDASH . ' not sincerity ' . Fixer::NDASH . ' is the vital thing.', $fixer->fix('Style - not sincerity - is the vital thing.'));
-        //$this->assertEquals("Style ".Fixer::MDASH." not sincerity ".Fixer::MDASH." is the vital thing.", $fixer->fix("Style -not sincerity- is the vital thing."));
+        // $this->assertEquals("Style ".Fixer::MDASH." not sincerity ".Fixer::MDASH." is the vital thing.", $fixer->fix("Style -not sincerity- is the vital thing."));
 
         $this->assertEquals('Style' . Fixer::MDASH . 'you have it.', $fixer->fix('Style -- you have it.'));
         $this->assertEquals('Style' . Fixer::MDASH . 'you have it.', $fixer->fix('Style--you have it.'));

--- a/tests/JoliTypo/Tests/Html5Test.php
+++ b/tests/JoliTypo/Tests/Html5Test.php
@@ -46,7 +46,7 @@ class Html5Test extends TestCase
             HTML;
 
         $fixed = <<<'STRING'
-            &#8220;Who Let the Dogs Out?&#8221; is a song written and originally recorded by Anslem Douglas (titled &#8220;Doggie&#8221;).
+            “Who Let the Dogs Out?” is a song written and originally recorded by Anslem Douglas (titled “Doggie”).
             STRING;
 
         $this->assertEquals($fixed, $fixer->fix($html));

--- a/tests/JoliTypo/Tests/JoliTypoTest.php
+++ b/tests/JoliTypo/Tests/JoliTypoTest.php
@@ -43,7 +43,7 @@ class JoliTypoTest extends TestCase
         $this->assertEquals('<p>Coucou&hellip;</p> <!-- Not Coucou... -->', $fixer->fix('<p>Coucou...</p> <!-- Not Coucou... -->'));
 
         // This test can't be ok, DomDocument is encoding entities even in comments (╯°□°）╯︵ ┻━┻
-        //$this->assertEquals("<p>Coucou&hellip;</p> <!-- abusé -->", $fixer->fix("<p>Coucou...</p> <!-- abusé -->"));
+        // $this->assertEquals("<p>Coucou&hellip;</p> <!-- abusé -->", $fixer->fix("<p>Coucou...</p> <!-- abusé -->"));
     }
 
     public function testBadRuleSets()


### PR DESCRIPTION
- Allow org_heigl/hyphenator in ^3.0
- Simplify composer.json 'scripts' section
- Drop support for Symfony < 4.4 + Add support for ^6.0
- Run tests on PHP 8.1
