### PR TITLE
Let assertEquals be strict for assertSame

### DIFF
--- a/tests/JoliTypo/Tests/EnglishTest.php
+++ b/tests/JoliTypo/Tests/EnglishTest.php
@@ -44,7 +44,7 @@ class EnglishTest extends TestCase
         $fixer = new Fixer($this->en_fixers);
         $this->assertInstanceOf('JoliTypo\Fixer', $fixer);
 
-        $this->assertEquals(self::FIXED, $fixer->fix(self::TOFIX));
+        $this->assertSame(self::FIXED, $fixer->fix(self::TOFIX));
     }
 
     public function testReadMeExemple()
@@ -59,7 +59,7 @@ class EnglishTest extends TestCase
 
         $fixer = new Fixer($this->en_fixers);
         $this->assertInstanceOf('JoliTypo\Fixer', $fixer);
-        $this->assertEquals($after, $fixer->fix($before));
+        $this->assertSame($after, $fixer->fix($before));
     }
 
     public function testDoubleQuoteMess()
@@ -74,7 +74,7 @@ class EnglishTest extends TestCase
         $fixer = new Fixer($this->en_fixers);
         $fixer->setLocale('en');
         $this->assertInstanceOf('JoliTypo\Fixer', $fixer);
-        $this->assertEquals($fixed, $fixer->fix($to_fix));
+        $this->assertSame($fixed, $fixer->fix($to_fix));
     }
 
     public function testHtmlHeart()
@@ -89,6 +89,6 @@ class EnglishTest extends TestCase
         $fixer = new Fixer($this->en_fixers);
         $fixer->setLocale('en');
         $this->assertInstanceOf('JoliTypo\Fixer', $fixer);
-        $this->assertEquals($fixed, $fixer->fix($to_fix));
+        $this->assertSame($fixed, $fixer->fix($to_fix));
     }
 }

--- a/tests/JoliTypo/Tests/Fixer/CurlyQuoteTest.php
+++ b/tests/JoliTypo/Tests/Fixer/CurlyQuoteTest.php
@@ -19,19 +19,19 @@ class CurlyQuoteTest extends TestCase
         $fixer = new Fixer\CurlyQuote();
         $this->assertInstanceOf('JoliTypo\Fixer\CurlyQuote', $fixer);
 
-        $this->assertEquals('This text in which there is a quote: I’m SUPERMAN.', $fixer->fix("This text in which there is a quote: I'm SUPERMAN."));
-        $this->assertEquals('Swag’', $fixer->fix("Swag'"));
-        $this->assertEquals('Swag’ me.', $fixer->fix("Swag' me."));
-        $this->assertEquals('J’aime la typographie.', $fixer->fix("J'aime la typographie."));
-        $this->assertEquals('Qu’est ce que l’univers ?', $fixer->fix("Qu'est ce que l'univers ?"));
+        $this->assertSame('This text in which there is a quote: I’m SUPERMAN.', $fixer->fix("This text in which there is a quote: I'm SUPERMAN."));
+        $this->assertSame('Swag’', $fixer->fix("Swag'"));
+        $this->assertSame('Swag’ me.', $fixer->fix("Swag' me."));
+        $this->assertSame('J’aime la typographie.', $fixer->fix("J'aime la typographie."));
+        $this->assertSame('Qu’est ce que l’univers ?', $fixer->fix("Qu'est ce que l'univers ?"));
     }
 
     public function testFalsePositives()
     {
         $fixer = new Fixer\CurlyQuote();
 
-        $this->assertEquals("She’s 6' 10\".", $fixer->fix("She's 6' 10\"."));
-        $this->assertEquals('This is a time: 2"44\'.', $fixer->fix('This is a time: 2"44\'.'));
-        $this->assertEquals("Here is a crying smiley: :'(", $fixer->fix("Here is a crying smiley: :'("));
+        $this->assertSame("She’s 6' 10\".", $fixer->fix("She's 6' 10\"."));
+        $this->assertSame('This is a time: 2"44\'.', $fixer->fix('This is a time: 2"44\'.'));
+        $this->assertSame("Here is a crying smiley: :'(", $fixer->fix("Here is a crying smiley: :'("));
     }
 }

--- a/tests/JoliTypo/Tests/Fixer/DashTest.php
+++ b/tests/JoliTypo/Tests/Fixer/DashTest.php
@@ -19,14 +19,14 @@ class DashTest extends TestCase
         $fixer = new Fixer\Dash();
         $this->assertInstanceOf('JoliTypo\Fixer\Dash', $fixer);
 
-        $this->assertEquals('Test', $fixer->fix('Test'));
-        $this->assertEquals('M. Jackson: 1964' . Fixer::NDASH . '2009', $fixer->fix('M. Jackson: 1964-2009'));
-        $this->assertEquals('M. Jackson: 1964 ' . Fixer::NDASH . ' 2009', $fixer->fix('M. Jackson: 1964 - 2009'));
-        $this->assertEquals('Style ' . Fixer::NDASH . ' not sincerity ' . Fixer::NDASH . ' is the vital thing.', $fixer->fix('Style - not sincerity - is the vital thing.'));
-        // $this->assertEquals("Style ".Fixer::MDASH." not sincerity ".Fixer::MDASH." is the vital thing.", $fixer->fix("Style -not sincerity- is the vital thing."));
+        $this->assertSame('Test', $fixer->fix('Test'));
+        $this->assertSame('M. Jackson: 1964' . Fixer::NDASH . '2009', $fixer->fix('M. Jackson: 1964-2009'));
+        $this->assertSame('M. Jackson: 1964 ' . Fixer::NDASH . ' 2009', $fixer->fix('M. Jackson: 1964 - 2009'));
+        $this->assertSame('Style ' . Fixer::NDASH . ' not sincerity ' . Fixer::NDASH . ' is the vital thing.', $fixer->fix('Style - not sincerity - is the vital thing.'));
+        // $this->assertSame("Style ".Fixer::MDASH." not sincerity ".Fixer::MDASH." is the vital thing.", $fixer->fix("Style -not sincerity- is the vital thing."));
 
-        $this->assertEquals('Style' . Fixer::MDASH . 'you have it.', $fixer->fix('Style -- you have it.'));
-        $this->assertEquals('Style' . Fixer::MDASH . 'you have it.', $fixer->fix('Style--you have it.'));
-        $this->assertEquals('Style' . Fixer::MDASH . 'you have it.', $fixer->fix('Style-- you have it.'));
+        $this->assertSame('Style' . Fixer::MDASH . 'you have it.', $fixer->fix('Style -- you have it.'));
+        $this->assertSame('Style' . Fixer::MDASH . 'you have it.', $fixer->fix('Style--you have it.'));
+        $this->assertSame('Style' . Fixer::MDASH . 'you have it.', $fixer->fix('Style-- you have it.'));
     }
 }

--- a/tests/JoliTypo/Tests/Fixer/DimensionTest.php
+++ b/tests/JoliTypo/Tests/Fixer/DimensionTest.php
@@ -19,13 +19,13 @@ class DimensionTest extends TestCase
         $fixer = new Fixer\Dimension();
         $this->assertInstanceOf('JoliTypo\Fixer\Dimension', $fixer);
 
-        $this->assertEquals('Test', $fixer->fix('Test'));
-        $this->assertEquals('TestxTest', $fixer->fix('TestxTest'));
-        $this->assertEquals('Here is a calcul: 99' . Fixer::TIMES . '122.21', $fixer->fix('Here is a calcul: 99x122.21'));
-        $this->assertEquals('Here is a calcul: 99 ' . Fixer::TIMES . ' 122.21', $fixer->fix('Here is a calcul: 99 x 122.21'));
-        $this->assertEquals('Here is a calcul: 99 1212,32 ' . Fixer::TIMES . ' 122.21', $fixer->fix('Here is a calcul: 99 1212,32 x 122.21'));
-        $this->assertEquals('3 ' . Fixer::TIMES . ' 1', $fixer->fix('3 x 1'));
-        $this->assertEquals('8.5"' . Fixer::TIMES . '10"', $fixer->fix('8.5"x10"'));
-        $this->assertEquals('8.5" ' . Fixer::TIMES . ' 10"', $fixer->fix('8.5" x 10"'));
+        $this->assertSame('Test', $fixer->fix('Test'));
+        $this->assertSame('TestxTest', $fixer->fix('TestxTest'));
+        $this->assertSame('Here is a calcul: 99' . Fixer::TIMES . '122.21', $fixer->fix('Here is a calcul: 99x122.21'));
+        $this->assertSame('Here is a calcul: 99 ' . Fixer::TIMES . ' 122.21', $fixer->fix('Here is a calcul: 99 x 122.21'));
+        $this->assertSame('Here is a calcul: 99 1212,32 ' . Fixer::TIMES . ' 122.21', $fixer->fix('Here is a calcul: 99 1212,32 x 122.21'));
+        $this->assertSame('3 ' . Fixer::TIMES . ' 1', $fixer->fix('3 x 1'));
+        $this->assertSame('8.5"' . Fixer::TIMES . '10"', $fixer->fix('8.5"x10"'));
+        $this->assertSame('8.5" ' . Fixer::TIMES . ' 10"', $fixer->fix('8.5" x 10"'));
     }
 }

--- a/tests/JoliTypo/Tests/Fixer/EllipsisTest.php
+++ b/tests/JoliTypo/Tests/Fixer/EllipsisTest.php
@@ -19,12 +19,12 @@ class EllipsisTest extends TestCase
         $fixer = new Fixer\Ellipsis();
         $this->assertInstanceOf('JoliTypo\Fixer\Ellipsis', $fixer);
 
-        $this->assertEquals('Test', $fixer->fix('Test'));
-        $this->assertEquals('Test…', $fixer->fix('Test...'));
-        $this->assertEquals('Am I an ellipsis?', $fixer->fix('Am I an ellipsis?'));
-        $this->assertEquals('Am I an ellipsis..', $fixer->fix('Am I an ellipsis..'));
-        $this->assertEquals('Am I an ellipsis…', $fixer->fix('Am I an ellipsis....'));
-        $this->assertEquals('Am I an ellipsis…', $fixer->fix('Am I an ellipsis…'));
-        $this->assertEquals('Am I an ellipsis… With following text.', $fixer->fix('Am I an ellipsis... With following text.'));
+        $this->assertSame('Test', $fixer->fix('Test'));
+        $this->assertSame('Test…', $fixer->fix('Test...'));
+        $this->assertSame('Am I an ellipsis?', $fixer->fix('Am I an ellipsis?'));
+        $this->assertSame('Am I an ellipsis..', $fixer->fix('Am I an ellipsis..'));
+        $this->assertSame('Am I an ellipsis…', $fixer->fix('Am I an ellipsis....'));
+        $this->assertSame('Am I an ellipsis…', $fixer->fix('Am I an ellipsis…'));
+        $this->assertSame('Am I an ellipsis… With following text.', $fixer->fix('Am I an ellipsis... With following text.'));
     }
 }

--- a/tests/JoliTypo/Tests/Fixer/EnglishQuotesTest.php
+++ b/tests/JoliTypo/Tests/Fixer/EnglishQuotesTest.php
@@ -33,15 +33,15 @@ class EnglishQuotesTest extends TestCase
     {
         $fixer = new Fixer\EnglishQuotes();
 
-        $this->assertEquals('This is a time: 2"44\'.', $fixer->fix('This is a time: 2"44\'.'));
-        $this->assertEquals('2"44\'.', $fixer->fix('2"44\'.'));
+        $this->assertSame('This is a time: 2"44\'.', $fixer->fix('This is a time: 2"44\'.'));
+        $this->assertSame('2"44\'.', $fixer->fix('2"44\'.'));
     }
 
     protected function basicStringsAsserts($fixer)
     {
-        $this->assertEquals('“I am smart”', $fixer->fix('"I am smart"'));
-        $this->assertEquals('Quote say: “I am smart”', $fixer->fix('Quote say: "I am smart"'));
-        $this->assertEquals("I'm not a “QUOTE”. Or a “US QUOTE.”", $fixer->fix('I\'m not a "QUOTE". Or a "US QUOTE."'));
-        $this->assertEquals("I'm not a (“QUOTE”. Or a “US QUOTE.”)", $fixer->fix('I\'m not a ("QUOTE". Or a "US QUOTE.")'));
+        $this->assertSame('“I am smart”', $fixer->fix('"I am smart"'));
+        $this->assertSame('Quote say: “I am smart”', $fixer->fix('Quote say: "I am smart"'));
+        $this->assertSame("I'm not a “QUOTE”. Or a “US QUOTE.”", $fixer->fix('I\'m not a "QUOTE". Or a "US QUOTE."'));
+        $this->assertSame("I'm not a (“QUOTE”. Or a “US QUOTE.”)", $fixer->fix('I\'m not a ("QUOTE". Or a "US QUOTE.")'));
     }
 }

--- a/tests/JoliTypo/Tests/Fixer/FrenchNoBreakSpaceTest.php
+++ b/tests/JoliTypo/Tests/Fixer/FrenchNoBreakSpaceTest.php
@@ -19,16 +19,16 @@ class FrenchNoBreakSpaceTest extends TestCase
         $fixer = new Fixer\FrenchNoBreakSpace();
         $this->assertInstanceOf('JoliTypo\Fixer\FrenchNoBreakSpace', $fixer);
 
-        $this->assertEquals('Superman' . Fixer::NO_BREAK_THIN_SPACE . '!', $fixer->fix('Superman !'));
-        $this->assertEquals('Superman' . Fixer::NO_BREAK_THIN_SPACE . '?', $fixer->fix('Superman ?'));
-        $this->assertEquals('Superman' . Fixer::NO_BREAK_THIN_SPACE . '!?', $fixer->fix('Superman !?'));
-        $this->assertEquals('Superman' . Fixer::NO_BREAK_THIN_SPACE . '? Nope.', $fixer->fix('Superman ? Nope.'));
-        $this->assertEquals('Superman' . Fixer::NO_BREAK_SPACE . ': the movie', $fixer->fix('Superman : the movie'));
-        $this->assertEquals('Superman: the movie', $fixer->fix('Superman: the movie'));
-        $this->assertEquals('Superman' . Fixer::NO_BREAK_THIN_SPACE . '; the movie', $fixer->fix('Superman ; the movie'));
-        $this->assertEquals('Superman' . Fixer::NO_BREAK_THIN_SPACE . '; the movie', $fixer->fix("Superman\u{a0}; the movie"));
-        $this->assertEquals('fdda:5cc1:23:4::1f', $fixer->fix('fdda:5cc1:23:4::1f'));
+        $this->assertSame('Superman' . Fixer::NO_BREAK_THIN_SPACE . '!', $fixer->fix('Superman !'));
+        $this->assertSame('Superman' . Fixer::NO_BREAK_THIN_SPACE . '?', $fixer->fix('Superman ?'));
+        $this->assertSame('Superman' . Fixer::NO_BREAK_THIN_SPACE . '!?', $fixer->fix('Superman !?'));
+        $this->assertSame('Superman' . Fixer::NO_BREAK_THIN_SPACE . '? Nope.', $fixer->fix('Superman ? Nope.'));
+        $this->assertSame('Superman' . Fixer::NO_BREAK_SPACE . ': the movie', $fixer->fix('Superman : the movie'));
+        $this->assertSame('Superman: the movie', $fixer->fix('Superman: the movie'));
+        $this->assertSame('Superman' . Fixer::NO_BREAK_THIN_SPACE . '; the movie', $fixer->fix('Superman ; the movie'));
+        $this->assertSame('Superman' . Fixer::NO_BREAK_THIN_SPACE . '; the movie', $fixer->fix("Superman\u{a0}; the movie"));
+        $this->assertSame('fdda:5cc1:23:4::1f', $fixer->fix('fdda:5cc1:23:4::1f'));
 
-        $this->assertEquals('Here is a  brand name: Yahoo!', $fixer->fix('Here is a  brand name: Yahoo!'));
+        $this->assertSame('Here is a  brand name: Yahoo!', $fixer->fix('Here is a  brand name: Yahoo!'));
     }
 }

--- a/tests/JoliTypo/Tests/Fixer/FrenchQuotesTest.php
+++ b/tests/JoliTypo/Tests/Fixer/FrenchQuotesTest.php
@@ -32,7 +32,7 @@ class FrenchQuotesTest extends TestCase
     {
         $fixer = new Fixer\FrenchQuotes();
 
-        $this->assertEquals('This is a time: 2"44\'.', $fixer->fix('This is a time: 2"44\'.'));
+        $this->assertSame('This is a time: 2"44\'.', $fixer->fix('This is a time: 2"44\'.'));
     }
 
     /**
@@ -44,18 +44,18 @@ class FrenchQuotesTest extends TestCase
 
         $fixer = new Fixer\FrenchQuotes();
 
-        $this->assertEquals('Oh my god, this quote is alone: " ! But those are «' . Fixer::NO_BREAK_SPACE . 'ok' . Fixer::NO_BREAK_SPACE . '».', $fixer->fix('Oh my god, this quote is alone: " ! But those are "ok".'));
+        $this->assertSame('Oh my god, this quote is alone: " ! But those are «' . Fixer::NO_BREAK_SPACE . 'ok' . Fixer::NO_BREAK_SPACE . '».', $fixer->fix('Oh my god, this quote is alone: " ! But those are "ok".'));
     }
 
     protected function basicStringsAsserts($fixer)
     {
-        $this->assertEquals('«' . Fixer::NO_BREAK_SPACE . 'Good code is like a good joke.' . Fixer::NO_BREAK_SPACE . '»', $fixer->fix('"Good code is like a good joke."'));
-        $this->assertEquals('«' . Fixer::NO_BREAK_SPACE . 'Good code is like a Bieber.' . Fixer::NO_BREAK_SPACE . '» - said no ever, ever.', $fixer->fix('"Good code is like a Bieber." - said no ever, ever.'));
+        $this->assertSame('«' . Fixer::NO_BREAK_SPACE . 'Good code is like a good joke.' . Fixer::NO_BREAK_SPACE . '»', $fixer->fix('"Good code is like a good joke."'));
+        $this->assertSame('«' . Fixer::NO_BREAK_SPACE . 'Good code is like a Bieber.' . Fixer::NO_BREAK_SPACE . '» - said no ever, ever.', $fixer->fix('"Good code is like a Bieber." - said no ever, ever.'));
 
-        $this->assertEquals('Some people are like «' . Fixer::NO_BREAK_SPACE . 'Batman' . Fixer::NO_BREAK_SPACE . '», others like «' . Fixer::NO_BREAK_SPACE . 'Superman' . Fixer::NO_BREAK_SPACE . '».', $fixer->fix('Some people are like "Batman", others like "Superman".'));
-        $this->assertEquals('Oh my god, this quote is alone: " !', $fixer->fix('Oh my god, this quote is alone: " !'));
+        $this->assertSame('Some people are like «' . Fixer::NO_BREAK_SPACE . 'Batman' . Fixer::NO_BREAK_SPACE . '», others like «' . Fixer::NO_BREAK_SPACE . 'Superman' . Fixer::NO_BREAK_SPACE . '».', $fixer->fix('Some people are like "Batman", others like "Superman".'));
+        $this->assertSame('Oh my god, this quote is alone: " !', $fixer->fix('Oh my god, this quote is alone: " !'));
 
-        $this->assertEquals('Liste de «' . Fixer::NO_BREAK_SPACE . 'mot' . Fixer::NO_BREAK_SPACE . '» entre «' . Fixer::NO_BREAK_SPACE . 'guillemets' . Fixer::NO_BREAK_SPACE . '».', $fixer->fix('Liste de "mot" entre "guillemets".'));
-        $this->assertEquals('Liste de («' . Fixer::NO_BREAK_SPACE . 'mot' . Fixer::NO_BREAK_SPACE . '» entre «' . Fixer::NO_BREAK_SPACE . 'guillemets' . Fixer::NO_BREAK_SPACE . '»).', $fixer->fix('Liste de ("mot" entre "guillemets").'));
+        $this->assertSame('Liste de «' . Fixer::NO_BREAK_SPACE . 'mot' . Fixer::NO_BREAK_SPACE . '» entre «' . Fixer::NO_BREAK_SPACE . 'guillemets' . Fixer::NO_BREAK_SPACE . '».', $fixer->fix('Liste de "mot" entre "guillemets".'));
+        $this->assertSame('Liste de («' . Fixer::NO_BREAK_SPACE . 'mot' . Fixer::NO_BREAK_SPACE . '» entre «' . Fixer::NO_BREAK_SPACE . 'guillemets' . Fixer::NO_BREAK_SPACE . '»).', $fixer->fix('Liste de ("mot" entre "guillemets").'));
     }
 }

--- a/tests/JoliTypo/Tests/Fixer/GermanQuotesTest.php
+++ b/tests/JoliTypo/Tests/Fixer/GermanQuotesTest.php
@@ -33,14 +33,14 @@ class GermanQuotesTest extends TestCase
     {
         $fixer = new Fixer\GermanQuotes();
 
-        $this->assertEquals('This is a time: 2"44\'.', $fixer->fix('This is a time: 2"44\'.'));
-        $this->assertEquals('2"44\'.', $fixer->fix('2"44\'.'));
+        $this->assertSame('This is a time: 2"44\'.', $fixer->fix('This is a time: 2"44\'.'));
+        $this->assertSame('2"44\'.', $fixer->fix('2"44\'.'));
     }
 
     protected function basicStringsAsserts($fixer)
     {
-        $this->assertEquals('„I am smart“', $fixer->fix('"I am smart"'));
-        $this->assertEquals('(„I am smart“)', $fixer->fix('("I am smart")'));
-        $this->assertEquals("Andreas fragte mich: „Hast du den Artikel 'EU-Erweiterung' gelesen?“", $fixer->fix('Andreas fragte mich: "Hast du den Artikel \'EU-Erweiterung\' gelesen?"'));
+        $this->assertSame('„I am smart“', $fixer->fix('"I am smart"'));
+        $this->assertSame('(„I am smart“)', $fixer->fix('("I am smart")'));
+        $this->assertSame("Andreas fragte mich: „Hast du den Artikel 'EU-Erweiterung' gelesen?“", $fixer->fix('Andreas fragte mich: "Hast du den Artikel \'EU-Erweiterung\' gelesen?"'));
     }
 }

--- a/tests/JoliTypo/Tests/Fixer/HyphenTest.php
+++ b/tests/JoliTypo/Tests/Fixer/HyphenTest.php
@@ -19,9 +19,9 @@ class HyphenTest extends TestCase
         $fixer = new Fixer\Hyphen('fr');
         $this->assertInstanceOf('JoliTypo\Fixer\Hyphen', $fixer);
 
-        $this->assertEquals('Test', $fixer->fix('Test'));
-        $this->assertEquals('Cordia' . Fixer::SHY . 'le' . Fixer::SHY . 'ment', $fixer->fix('Cordialement'));
-        $this->assertEquals('Cordia' . Fixer::SHY . 'le' . Fixer::SHY . 'ment' . Fixer::NO_BREAK_THIN_SPACE . '!', $fixer->fix('Cordialement' . Fixer::NO_BREAK_THIN_SPACE . '!'));
+        $this->assertSame('Test', $fixer->fix('Test'));
+        $this->assertSame('Cordia' . Fixer::SHY . 'le' . Fixer::SHY . 'ment', $fixer->fix('Cordialement'));
+        $this->assertSame('Cordia' . Fixer::SHY . 'le' . Fixer::SHY . 'ment' . Fixer::NO_BREAK_THIN_SPACE . '!', $fixer->fix('Cordialement' . Fixer::NO_BREAK_THIN_SPACE . '!'));
     }
 
     public function testLocaleFallback()
@@ -29,15 +29,15 @@ class HyphenTest extends TestCase
         $fixer = new Fixer\Hyphen('fr_BE');
         $this->assertInstanceOf('JoliTypo\Fixer\Hyphen', $fixer);
 
-        $this->assertEquals('Test', $fixer->fix('Test'));
-        $this->assertEquals('Cordia' . Fixer::SHY . 'le' . Fixer::SHY . 'ment', $fixer->fix('Cordialement'));
+        $this->assertSame('Test', $fixer->fix('Test'));
+        $this->assertSame('Cordia' . Fixer::SHY . 'le' . Fixer::SHY . 'ment', $fixer->fix('Cordialement'));
     }
 
     public function testNonExistingLocale()
     {
         $fixer = new Fixer\Hyphen('toto');
 
-        $this->assertEquals('Test', $fixer->fix('Test'));
-        $this->assertEquals('Cordialement', $fixer->fix('Cordialement'));
+        $this->assertSame('Test', $fixer->fix('Test'));
+        $this->assertSame('Cordialement', $fixer->fix('Cordialement'));
     }
 }

--- a/tests/JoliTypo/Tests/Fixer/NoSpaceBeforeCommaTest.php
+++ b/tests/JoliTypo/Tests/Fixer/NoSpaceBeforeCommaTest.php
@@ -19,10 +19,10 @@ class NoSpaceBeforeCommaTest extends TestCase
         $fixer = new Fixer\NoSpaceBeforeComma();
         $this->assertInstanceOf('JoliTypo\Fixer\NoSpaceBeforeComma', $fixer);
 
-        $this->assertEquals("Superman, you're my hero", $fixer->fix("Superman,you're my hero"));
-        $this->assertEquals("Superman, you're my hero", $fixer->fix("Superman ,you're my hero"));
-        $this->assertEquals("Superman, you're my hero", $fixer->fix("Superman  ,  you're my hero"));
-        $this->assertEquals('F, bar', $fixer->fix('F,bar'));
-        $this->assertEquals('Seule 1,7 million de personnes', $fixer->fix('Seule 1,7 million de personnes'));
+        $this->assertSame("Superman, you're my hero", $fixer->fix("Superman,you're my hero"));
+        $this->assertSame("Superman, you're my hero", $fixer->fix("Superman ,you're my hero"));
+        $this->assertSame("Superman, you're my hero", $fixer->fix("Superman  ,  you're my hero"));
+        $this->assertSame('F, bar', $fixer->fix('F,bar'));
+        $this->assertSame('Seule 1,7 million de personnes', $fixer->fix('Seule 1,7 million de personnes'));
     }
 }

--- a/tests/JoliTypo/Tests/Fixer/SmartQuotesTest.php
+++ b/tests/JoliTypo/Tests/Fixer/SmartQuotesTest.php
@@ -20,17 +20,17 @@ class SmartQuotesTest extends TestCase
         $fixer = new Fixer\SmartQuotes('de');
         $this->assertInstanceOf('JoliTypo\Fixer\SmartQuotes', $fixer);
 
-        $this->assertEquals('„I am smart“', $fixer->fix('"I am smart"'));
+        $this->assertSame('„I am smart“', $fixer->fix('"I am smart"'));
 
         $fixer->setOpening('«');
         $fixer->setClosing('»');
 
-        $this->assertEquals('«I am smart»', $fixer->fix('"I am smart"'));
+        $this->assertSame('«I am smart»', $fixer->fix('"I am smart"'));
 
         $fixer->setOpening('<');
         $fixer->setClosing('>');
 
-        $this->assertEquals('<I am smart>', $fixer->fix('"I am smart"'));
+        $this->assertSame('<I am smart>', $fixer->fix('"I am smart"'));
     }
 
     public function testBadConfig()

--- a/tests/JoliTypo/Tests/Fixer/TrademarkTest.php
+++ b/tests/JoliTypo/Tests/Fixer/TrademarkTest.php
@@ -19,14 +19,14 @@ class TrademarkTest extends TestCase
         $fixer = new Fixer\Trademark();
         $this->assertInstanceOf('JoliTypo\Fixer\Trademark', $fixer);
 
-        $this->assertEquals('Test', $fixer->fix('Test'));
-        $this->assertEquals('(c(', $fixer->fix('(c('));
-        $this->assertEquals('©', $fixer->fix('(c)'));
-        $this->assertEquals('Protip©', $fixer->fix('Protip(c)'));
-        $this->assertEquals('Protip ©.', $fixer->fix('Protip (c).'));
-        $this->assertEquals('©®™.', $fixer->fix('(c)(r)(tm).'));
-        $this->assertEquals('©®™.', $fixer->fix('(C)(R)(TM).'));
-        $this->assertEquals('©' . Fixer::NO_BREAK_SPACE . '2013 Acme Corp™', $fixer->fix('(C) 2013 Acme Corp(TM)'));
+        $this->assertSame('Test', $fixer->fix('Test'));
+        $this->assertSame('(c(', $fixer->fix('(c('));
+        $this->assertSame('©', $fixer->fix('(c)'));
+        $this->assertSame('Protip©', $fixer->fix('Protip(c)'));
+        $this->assertSame('Protip ©.', $fixer->fix('Protip (c).'));
+        $this->assertSame('©®™.', $fixer->fix('(c)(r)(tm).'));
+        $this->assertSame('©®™.', $fixer->fix('(C)(R)(TM).'));
+        $this->assertSame('©' . Fixer::NO_BREAK_SPACE . '2013 Acme Corp™', $fixer->fix('(C) 2013 Acme Corp(TM)'));
     }
 
     /**
@@ -39,6 +39,6 @@ class TrademarkTest extends TestCase
         $fixer = new Fixer\Trademark();
 
         // Reference, section like this:
-        $this->assertEquals('Section 12(c)', $fixer->fix('Section 12(c)'));
+        $this->assertSame('Section 12(c)', $fixer->fix('Section 12(c)'));
     }
 }

--- a/tests/JoliTypo/Tests/Fixer/UnitTest.php
+++ b/tests/JoliTypo/Tests/Fixer/UnitTest.php
@@ -19,20 +19,20 @@ class UnitTest extends TestCase
         $fixer = new Fixer\Unit();
         $this->assertInstanceOf('JoliTypo\Fixer\Unit', $fixer);
 
-        $this->assertEquals('Test', $fixer->fix('Test'));
-        $this->assertEquals('1' . Fixer::NO_BREAK_SPACE . 'h', $fixer->fix('1 h'));
-        $this->assertEquals('2' . Fixer::NO_BREAK_SPACE . '฿', $fixer->fix('2 ฿'));
-        $this->assertEquals('3' . Fixer::NO_BREAK_SPACE . 'things', $fixer->fix('3 things'));
-        $this->assertEquals('4,5' . Fixer::NO_BREAK_SPACE . 'km', $fixer->fix('4,5 km'));
-        $this->assertEquals('5.1' . Fixer::NO_BREAK_SPACE . 'deg', $fixer->fix('5.1 deg'));
-        $this->assertEquals('6' . Fixer::NO_BREAK_SPACE . 'ºC', $fixer->fix('6 ºC'));
-        $this->assertEquals('7' . Fixer::NO_BREAK_SPACE . '$', $fixer->fix('7 $'));
-        $this->assertEquals('8º' . Fixer::NO_BREAK_SPACE . '18′ 30″', $fixer->fix('8º 18′ 30″'));
-        $this->assertEquals('9' . Fixer::NO_BREAK_SPACE . 'hours', $fixer->fix('9 hours'));
-        $this->assertEquals('10e position', $fixer->fix('10e position')); // We can't fix this reliably
-        $this->assertEquals('nº' . Fixer::NO_BREAK_SPACE . '11', $fixer->fix('nº 11'));
-        $this->assertEquals('12' . Fixer::NO_BREAK_SPACE . '%', $fixer->fix('12 %'));
-        $this->assertEquals('13' . Fixer::NO_BREAK_SPACE . 'Ω', $fixer->fix('13 Ω'));
-        $this->assertEquals('14' . Fixer::NO_BREAK_SPACE . 'Ω', $fixer->fix('14' . Fixer::NO_BREAK_THIN_SPACE . 'Ω'));
+        $this->assertSame('Test', $fixer->fix('Test'));
+        $this->assertSame('1' . Fixer::NO_BREAK_SPACE . 'h', $fixer->fix('1 h'));
+        $this->assertSame('2' . Fixer::NO_BREAK_SPACE . '฿', $fixer->fix('2 ฿'));
+        $this->assertSame('3' . Fixer::NO_BREAK_SPACE . 'things', $fixer->fix('3 things'));
+        $this->assertSame('4,5' . Fixer::NO_BREAK_SPACE . 'km', $fixer->fix('4,5 km'));
+        $this->assertSame('5.1' . Fixer::NO_BREAK_SPACE . 'deg', $fixer->fix('5.1 deg'));
+        $this->assertSame('6' . Fixer::NO_BREAK_SPACE . 'ºC', $fixer->fix('6 ºC'));
+        $this->assertSame('7' . Fixer::NO_BREAK_SPACE . '$', $fixer->fix('7 $'));
+        $this->assertSame('8º' . Fixer::NO_BREAK_SPACE . '18′ 30″', $fixer->fix('8º 18′ 30″'));
+        $this->assertSame('9' . Fixer::NO_BREAK_SPACE . 'hours', $fixer->fix('9 hours'));
+        $this->assertSame('10e position', $fixer->fix('10e position')); // We can't fix this reliably
+        $this->assertSame('nº' . Fixer::NO_BREAK_SPACE . '11', $fixer->fix('nº 11'));
+        $this->assertSame('12' . Fixer::NO_BREAK_SPACE . '%', $fixer->fix('12 %'));
+        $this->assertSame('13' . Fixer::NO_BREAK_SPACE . 'Ω', $fixer->fix('13 Ω'));
+        $this->assertSame('14' . Fixer::NO_BREAK_SPACE . 'Ω', $fixer->fix('14' . Fixer::NO_BREAK_THIN_SPACE . 'Ω'));
     }
 }

--- a/tests/JoliTypo/Tests/FrenchTest.php
+++ b/tests/JoliTypo/Tests/FrenchTest.php
@@ -69,7 +69,7 @@ class FrenchTest extends TestCase
         $fixer->setLocale('fr_FR');
         $this->assertInstanceOf('JoliTypo\Fixer', $fixer);
 
-        $this->assertEquals(self::FIXED, $fixer->fix(self::TOFIX));
+        $this->assertSame(self::FIXED, $fixer->fix(self::TOFIX));
     }
 
     public function testFixFullTextShort()
@@ -78,7 +78,7 @@ class FrenchTest extends TestCase
         $fixer->setLocale('fr');
         $this->assertInstanceOf('JoliTypo\Fixer', $fixer);
 
-        $this->assertEquals(self::FIXED, $fixer->fix(self::TOFIX));
+        $this->assertSame(self::FIXED, $fixer->fix(self::TOFIX));
     }
 
     public function testDoubleQuoteMess()
@@ -97,7 +97,7 @@ class FrenchTest extends TestCase
              attirera forcément plus notre attention qu’une lettre de motivation de 4 pages en ".docx"</p>
             HTML;
 
-        $this->assertEquals($fixed, $fixer->fix($to_fix));
+        $this->assertSame($fixed, $fixer->fix($to_fix));
     }
 
     public function testEncodingMess()
@@ -114,7 +114,7 @@ class FrenchTest extends TestCase
             Ça s'arrête là !
             HTML;
 
-        $this->assertEquals($fixed, $fixer->fix($to_fix));
+        $this->assertSame($fixed, $fixer->fix($to_fix));
     }
 
     /**
@@ -135,13 +135,13 @@ class FrenchTest extends TestCase
             « test » et «test» sont dans un bateau.
             HTML;
 
-        $this->assertEquals($fixed, $fixer->fix($to_fix));
+        $this->assertSame($fixed, $fixer->fix($to_fix));
 
         $to_fix = <<<'HTML'
             &laquo; test &raquo; et &laquo;test&raquo; sont dans un bateau.
             HTML;
 
-        $this->assertEquals($fixed, $fixer->fix($to_fix));
+        $this->assertSame($fixed, $fixer->fix($to_fix));
     }
 
     /**
@@ -162,7 +162,7 @@ class FrenchTest extends TestCase
             2 x 5 doit être corrigé, et 2 h aussi.
             HTML;
 
-        $this->assertEquals($fixed, $fixer->fix($to_fix));
+        $this->assertSame($fixed, $fixer->fix($to_fix));
     }
 
     /**

--- a/tests/JoliTypo/Tests/Html5Test.php
+++ b/tests/JoliTypo/Tests/Html5Test.php
@@ -24,7 +24,7 @@ class Html5Test extends TestCase
             HTML;
 
         // The test passes if there is no warning about this fix:
-        $this->assertEquals($html5, $fixer->fix($html5));
+        $this->assertSame($html5, $fixer->fix($html5));
     }
 
     public function testFullPageMarkup()
@@ -49,6 +49,6 @@ class Html5Test extends TestCase
             “Who Let the Dogs Out?” is a song written and originally recorded by Anslem Douglas (titled “Doggie”).
             STRING;
 
-        $this->assertEquals($fixed, $fixer->fix($html));
+        $this->assertSame($fixed, $fixer->fix($html));
     }
 }

--- a/tests/JoliTypo/Tests/JoliTypoTest.php
+++ b/tests/JoliTypo/Tests/JoliTypoTest.php
@@ -22,7 +22,7 @@ class JoliTypoTest extends TestCase
         $fixer = new Fixer(['Ellipsis']);
         $this->assertInstanceOf('JoliTypo\Fixer', $fixer);
 
-        $this->assertEquals('Coucou&hellip;', $fixer->fix('Coucou...'));
+        $this->assertSame('Coucou&hellip;', $fixer->fix('Coucou...'));
     }
 
     public function testSimpleInstanceRulesChange()
@@ -30,20 +30,20 @@ class JoliTypoTest extends TestCase
         $fixer = new Fixer(['Ellipsis']);
         $this->assertInstanceOf('JoliTypo\Fixer', $fixer);
 
-        $this->assertEquals('Coucou&hellip;', $fixer->fix('Coucou...'));
+        $this->assertSame('Coucou&hellip;', $fixer->fix('Coucou...'));
 
         $fixer->setRules(['CurlyQuote']);
 
-        $this->assertEquals('I&rsquo;m a pony.', $fixer->fix("I'm a pony."));
+        $this->assertSame('I&rsquo;m a pony.', $fixer->fix("I'm a pony."));
     }
 
     public function testHtmlComments()
     {
         $fixer = new Fixer(['Ellipsis']);
-        $this->assertEquals('<p>Coucou&hellip;</p> <!-- Not Coucou... -->', $fixer->fix('<p>Coucou...</p> <!-- Not Coucou... -->'));
+        $this->assertSame('<p>Coucou&hellip;</p> <!-- Not Coucou... -->', $fixer->fix('<p>Coucou...</p> <!-- Not Coucou... -->'));
 
         // This test can't be ok, DomDocument is encoding entities even in comments (╯°□°）╯︵ ┻━┻
-        // $this->assertEquals("<p>Coucou&hellip;</p> <!-- abusé -->", $fixer->fix("<p>Coucou...</p> <!-- abusé -->"));
+        // $this->assertSame("<p>Coucou&hellip;</p> <!-- abusé -->", $fixer->fix("<p>Coucou...</p> <!-- abusé -->"));
     }
 
     public function testBadRuleSets()
@@ -87,7 +87,7 @@ class JoliTypoTest extends TestCase
     {
         $fixer = new Fixer([new OkFixer()]);
 
-        $this->assertEquals('<p>Nope !</p>', $fixer->fix('<p>Nope !</p>'));
+        $this->assertSame('<p>Nope !</p>', $fixer->fix('<p>Nope !</p>'));
     }
 
     public function testProtectedTags()
@@ -96,7 +96,7 @@ class JoliTypoTest extends TestCase
         $fixer->setProtectedTags(['pre', 'a']);
         $fixed_content = $fixer->fix('<p>Fixed...</p> <pre>Not fixed...</pre> <p>Fixed... <a>Not Fixed...</a>.</p>');
 
-        $this->assertEquals('<p>Fixed&hellip;</p> <pre>Not fixed...</pre> <p>Fixed&hellip; <a>Not Fixed...</a>.</p>', $fixed_content);
+        $this->assertSame('<p>Fixed&hellip;</p> <pre>Not fixed...</pre> <p>Fixed&hellip; <a>Not Fixed...</a>.</p>', $fixed_content);
     }
 
     public function testBadClassName()
@@ -126,8 +126,8 @@ class JoliTypoTest extends TestCase
         $fixer = new Fixer(['Ellipsis']);
         $this->assertInstanceOf('JoliTypo\Fixer', $fixer);
 
-        $this->assertEquals('<p>Hey &eacute;pic dude&hellip;</p>', $fixer->fix('<?xml encoding="UTF-8"><body><p>Hey épic dude...</p></body>'));
-        $this->assertEquals('<p>Hey &eacute;pic dude&hellip;</p>', $fixer->fix('<?xml encoding="ISO-8859-1"><body><p>Hey épic dude...</p></body>'));
+        $this->assertSame('<p>Hey &eacute;pic dude&hellip;</p>', $fixer->fix('<?xml encoding="UTF-8"><body><p>Hey épic dude...</p></body>'));
+        $this->assertSame('<p>Hey &eacute;pic dude&hellip;</p>', $fixer->fix('<?xml encoding="ISO-8859-1"><body><p>Hey épic dude...</p></body>'));
     }
 
     public function testBadEncoding()
@@ -135,13 +135,13 @@ class JoliTypoTest extends TestCase
         $fixer = new Fixer(['Trademark']);
         $this->assertInstanceOf('JoliTypo\Fixer', $fixer);
 
-        $this->assertEquals('Mentions L&eacute;gales', $fixer->fix(utf8_encode(utf8_decode('Mentions Légales'))));
+        $this->assertSame('Mentions L&eacute;gales', $fixer->fix(utf8_encode(utf8_decode('Mentions Légales'))));
 
         // JoliTypo can handle double encoded UTF-8 strings, or ISO strings, but that's not a feature.
         $isoString = mb_convert_encoding('Mentions Légales', 'ISO-8859-1', 'UTF-8');
-        $this->assertEquals('Mentions L&eacute;gales', $fixer->fix(utf8_encode($isoString)));
-        $this->assertEquals('Mentions L&eacute;gales', $fixer->fix($isoString));
-        $this->assertEquals('Mentions L&Atilde;&copy;gales', $fixer->fix(utf8_encode(utf8_encode($isoString))));
+        $this->assertSame('Mentions L&eacute;gales', $fixer->fix(utf8_encode($isoString)));
+        $this->assertSame('Mentions L&eacute;gales', $fixer->fix($isoString));
+        $this->assertSame('Mentions L&Atilde;&copy;gales', $fixer->fix(utf8_encode(utf8_encode($isoString))));
     }
 
     public function testEmptyContent()
@@ -149,9 +149,9 @@ class JoliTypoTest extends TestCase
         $fixer = new Fixer(['Trademark']);
         $this->assertInstanceOf('JoliTypo\Fixer', $fixer);
 
-        $this->assertEquals('', $fixer->fix(''));
-        $this->assertEquals("\n ", $fixer->fix("\n "));
-        $this->assertEquals('some content &reg;', $fixer->fix("\n some content (r)"));
+        $this->assertSame('', $fixer->fix(''));
+        $this->assertSame("\n ", $fixer->fix("\n "));
+        $this->assertSame('some content &reg;', $fixer->fix("\n some content (r)"));
     }
 
     public function testNonHTMLContent()
@@ -170,9 +170,9 @@ class JoliTypoTest extends TestCase
             \tThat being said, it's an awesome way to get stuffs done&copy; in a snap!
             NOT_HTML;
 
-        $this->assertEquals($fixed, $fixer->fix($toFix));
-        $this->assertEquals(html_entity_decode($fixed, \ENT_COMPAT, 'UTF-8'), $fixer->fixString($toFix));
-        $this->assertEquals('Here is a “protip©”!', $fixer->fixString('Here is a "protip(c)"!'));
+        $this->assertSame($fixed, $fixer->fix($toFix));
+        $this->assertSame(html_entity_decode($fixed, \ENT_COMPAT, 'UTF-8'), $fixer->fixString($toFix));
+        $this->assertSame('Here is a “protip©”!', $fixer->fixString('Here is a "protip(c)"!'));
     }
 
     /** @group legacy */
@@ -181,7 +181,7 @@ class JoliTypoTest extends TestCase
         $fixer = new Fixer(['Numeric']);
         $this->assertInstanceOf('JoliTypo\Fixer', $fixer);
 
-        $this->assertEquals('3' . Fixer::NO_BREAK_SPACE . '€', $fixer->fixString('3 €'));
+        $this->assertSame('3' . Fixer::NO_BREAK_SPACE . '€', $fixer->fixString('3 €'));
     }
 }
 


### PR DESCRIPTION
# Changed log

- As title, using the `assertSame` to replace `assertEquals` and make these assertions strict.