### PR TITLE
fix: fixed extending final class (DomException)

### DIFF
--- a/src/JoliTypo/Exception/InvalidMarkupException.php
+++ b/src/JoliTypo/Exception/InvalidMarkupException.php
@@ -9,7 +9,7 @@
 
 namespace JoliTypo\Exception;
 
-class InvalidMarkupException extends \DOMException
+class InvalidMarkupException extends \RuntimeException
 {
     protected $message = 'An error happened when trying to read your HTML with \\DOMDocument.';
 }


### PR DESCRIPTION
## CHANGES

* `Exception\InvalidMarkupException` is now extend the `RuntimeException` instead of `DomException`.

## EXPLAINATION

`DomException` is a [final class](https://www.php.net/manual/en/class.domexception.php), I think It exist because PHP use this exception internally when working with the DOM extension.

```php
// Change libxml config
$libxmlCurrent = libxml_use_internal_errors(true);

$loaded = $dom->loadHTML($this->fixContentEncoding($content));

// Restore libxml config
libxml_use_internal_errors($libxmlCurrent);

if (!$loaded) {
    throw new InvalidMarkupException("Can't load the given HTML via DomDocument");
}
```

Here in your code, if the `$loaded` variable is false, a fatal error will be raised as the following:

```bash
Fatal error: Class JoliTypo\Exception\InvalidMarkupException may not inherit from final class (DOMException) in /workspaces/JoliTypo/src/JoliTypo/Exception/InvalidMarkupException.php on line 15
```

