### PR TITLE
Switch to more semantic exception classes

### DIFF
--- a/src/JoliTypo/Exception/BadFixerConfigurationException.php
+++ b/src/JoliTypo/Exception/BadFixerConfigurationException.php
@@ -9,7 +9,7 @@
 
 namespace JoliTypo\Exception;
 
-class BadFixerConfigurationException extends \Exception
+class BadFixerConfigurationException extends \InvalidArgumentException
 {
     protected $message = 'Fixer needs configuration.';
 }

--- a/src/JoliTypo/Exception/BadRuleSetException.php
+++ b/src/JoliTypo/Exception/BadRuleSetException.php
@@ -9,7 +9,7 @@
 
 namespace JoliTypo\Exception;
 
-class BadRuleSetException extends \Exception
+class BadRuleSetException extends \InvalidArgumentException
 {
     protected $message = 'RuleSet must be an array of Fixer names or instances.';
 }


### PR DESCRIPTION
## CHANGES

* `Exception\BadRuleSetException` is now extend the `InvalidArgumentException`.
* `Exception\BadFixerConfigurationException` is now extend the `LogicException`.

## EXPLANATION

* We use the `BadRuleSetException` exception in many situations where for ex the passed rules array is empty or contains wrong rules, or when passing an invalid fixer instance, for all those situations I see the `InvalidArgumentException` class is more semantic.
* For the `BadFixerConfigurationException`, this exception is thrown if an invalid local config was passed with the constructor of the fixer, this should lead to a direct fix in the code and changed the passed local to valid one, so I think here extending `InvalidArgumentException` is more semantic and appropriate.