### PR TITLE
Upgrade the code base to support type declarations features (PHP 7.4 and prior)

### DIFF
--- a/src/JoliTypo/Bridge/Symfony/DependencyInjection/Configuration.php
+++ b/src/JoliTypo/Bridge/Symfony/DependencyInjection/Configuration.php
@@ -11,6 +11,8 @@ namespace JoliTypo\Bridge\Symfony\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 
 class Configuration implements ConfigurationInterface
 {
@@ -44,7 +46,7 @@ class Configuration implements ConfigurationInterface
     }
 
     /**
-     * @return \Symfony\Component\Config\Definition\Builder\NodeDefinition|\Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition
+     * @return NodeDefinition|ArrayNodeDefinition
      */
     private function getRootNode(TreeBuilder $treeBuilder, string $name)
     {

--- a/src/JoliTypo/Bridge/Symfony/DependencyInjection/Configuration.php
+++ b/src/JoliTypo/Bridge/Symfony/DependencyInjection/Configuration.php
@@ -43,7 +43,10 @@ class Configuration implements ConfigurationInterface
         return $treeBuilder;
     }
 
-    private function getRootNode(TreeBuilder $treeBuilder, $name)
+    /**
+     * @return \Symfony\Component\Config\Definition\Builder\NodeDefinition|\Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition
+     */
+    private function getRootNode(TreeBuilder $treeBuilder, string $name)
     {
         // BC layer for symfony/config 4.1 and older
         if (!\method_exists($treeBuilder, 'getRootNode')) {

--- a/src/JoliTypo/Bridge/Symfony/DependencyInjection/JoliTypoExtension.php
+++ b/src/JoliTypo/Bridge/Symfony/DependencyInjection/JoliTypoExtension.php
@@ -35,7 +35,7 @@ class JoliTypoExtension extends Extension
         $container->setDefinition('joli_typo.twig_extension', $twigExtension);
     }
 
-    private function createPresetDefinition(ContainerBuilder $container, $config)
+    private function createPresetDefinition(ContainerBuilder $container, array $config): array
     {
         $presets = [];
 

--- a/src/JoliTypo/Bridge/Twig/JoliTypoExtension.php
+++ b/src/JoliTypo/Bridge/Twig/JoliTypoExtension.php
@@ -28,7 +28,6 @@ class JoliTypoExtension extends AbstractExtension
         ];
     }
 
-
     public function getFilters(): array
     {
         return [

--- a/src/JoliTypo/Bridge/Twig/JoliTypoExtension.php
+++ b/src/JoliTypo/Bridge/Twig/JoliTypoExtension.php
@@ -14,9 +14,9 @@ use Twig\Extension\AbstractExtension;
 
 class JoliTypoExtension extends AbstractExtension
 {
-    private $presets = [];
+    private array $presets = [];
 
-    public function __construct($presets)
+    public function __construct(array $presets)
     {
         $this->presets = $presets;
     }
@@ -28,6 +28,7 @@ class JoliTypoExtension extends AbstractExtension
         ];
     }
 
+
     public function getFilters(): array
     {
         return [
@@ -35,7 +36,10 @@ class JoliTypoExtension extends AbstractExtension
         ];
     }
 
-    public function translate($text, $preset = 'default')
+    /**
+     * @throws \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     */
+    public function translate($text, $preset = 'default'): string
     {
         if (!isset($this->presets[$preset])) {
             throw new InvalidConfigurationException(sprintf("There is no '%s' preset configured.", $preset));
@@ -44,7 +48,7 @@ class JoliTypoExtension extends AbstractExtension
         return $this->presets[$preset]->fix($text);
     }
 
-    public function getName()
+    public function getName(): string
     {
         return 'jolitypo';
     }

--- a/src/JoliTypo/Bridge/Twig/JoliTypoExtension.php
+++ b/src/JoliTypo/Bridge/Twig/JoliTypoExtension.php
@@ -36,7 +36,7 @@ class JoliTypoExtension extends AbstractExtension
     }
 
     /**
-     * @throws \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     * @throws InvalidConfigurationException
      */
     public function translate($text, $preset = 'default'): string
     {

--- a/src/JoliTypo/Fixer.php
+++ b/src/JoliTypo/Fixer.php
@@ -95,7 +95,7 @@ class Fixer
 
     /**
      * @param string $content Basic content to fix
-     * 
+     *
      * @return string
      */
     public function fixString(string $content)
@@ -109,9 +109,9 @@ class Fixer
 
     /**
      * Change the list of rules for a given locale.
-     * 
+     *
      * @return void
-     * 
+     *
      * @throws BadRuleSetException
      */
     public function setRules(array $rules)
@@ -121,7 +121,7 @@ class Fixer
 
     /**
      * Customize the list of protected tags.
-     * 
+     *
      * @return void
      */
     public function setProtectedTags(array $protectedTags)
@@ -131,7 +131,7 @@ class Fixer
 
     /**
      * Get the current Locale tag.
-     * 
+     *
      * @return string
      */
     public function getLocale()
@@ -143,7 +143,7 @@ class Fixer
      * Change the locale of the Fixer.
      *
      * @param string $locale An IETF language tag
-     * 
+     *
      * @return void
      *
      * @throws \InvalidArgumentException
@@ -166,7 +166,7 @@ class Fixer
 
     /**
      * Get language part of a Locale string (fr_FR => fr).
-     * 
+     *
      * @return string
      */
     public static function getLanguageFromLocale($locale)

--- a/src/JoliTypo/Fixer.php
+++ b/src/JoliTypo/Fixer.php
@@ -58,7 +58,10 @@ class Fixer
      */
     protected $_rules = [];
 
-    protected $stateBag = null;
+    /**
+     * @var StateBag
+     */
+    protected $stateBag;
 
     /**
      * @param array $rules Array of Fixer
@@ -92,6 +95,8 @@ class Fixer
 
     /**
      * @param string $content Basic content to fix
+     * 
+     * @return string
      */
     public function fixString(string $content)
     {
@@ -105,6 +110,8 @@ class Fixer
     /**
      * Change the list of rules for a given locale.
      * 
+     * @return void
+     * 
      * @throws BadRuleSetException
      */
     public function setRules(array $rules)
@@ -114,6 +121,8 @@ class Fixer
 
     /**
      * Customize the list of protected tags.
+     * 
+     * @return void
      */
     public function setProtectedTags(array $protectedTags)
     {
@@ -122,6 +131,8 @@ class Fixer
 
     /**
      * Get the current Locale tag.
+     * 
+     * @return string
      */
     public function getLocale()
     {
@@ -132,6 +143,8 @@ class Fixer
      * Change the locale of the Fixer.
      *
      * @param string $locale An IETF language tag
+     * 
+     * @return void
      *
      * @throws \InvalidArgumentException
      */
@@ -153,6 +166,8 @@ class Fixer
 
     /**
      * Get language part of a Locale string (fr_FR => fr).
+     * 
+     * @return string
      */
     public static function getLanguageFromLocale($locale)
     {

--- a/src/JoliTypo/Fixer.php
+++ b/src/JoliTypo/Fixer.php
@@ -72,8 +72,6 @@ class Fixer
      * @param string $content HTML content to fix
      *
      * @return string Fixed content
-     *
-     * @throws Exception\BadRuleSetException
      */
     public function fix(string $content): string
     {

--- a/src/JoliTypo/Fixer.php
+++ b/src/JoliTypo/Fixer.php
@@ -104,9 +104,7 @@ class Fixer
 
     /**
      * Change the list of rules for a given locale.
-     *
-     * @param array $rules Array of Fixer
-     *
+     * 
      * @throws Exception\BadRuleSetException
      */
     public function setRules(array $rules)

--- a/src/JoliTypo/Fixer.php
+++ b/src/JoliTypo/Fixer.php
@@ -46,27 +46,24 @@ class Fixer
     /**
      * @var array HTML Tags to bypass
      */
-    protected $protectedTags = ['head', 'link', 'pre', 'code', 'script', 'style'];
+    protected array $protectedTags = ['head', 'link', 'pre', 'code', 'script', 'style'];
 
     /**
      * @var string The default locale (used by some Fixer)
      */
-    protected $locale = 'en_GB';
+    protected string $locale = 'en_GB';
 
     /**
      * @var array<FixerInterface> The rules Fixer instances to apply on each DOMText
      */
-    protected $_rules = [];
+    protected array $_rules = [];
 
-    /**
-     * @var StateBag
-     */
-    protected $stateBag;
+    protected StateBag $stateBag;
 
     /**
      * @param array $rules Array of Fixer
      */
-    public function __construct($rules)
+    public function __construct(array $rules)
     {
         $this->compileRules($rules);
     }
@@ -78,7 +75,7 @@ class Fixer
      *
      * @throws Exception\BadRuleSetException
      */
-    public function fix($content)
+    public function fix(string $content): string
     {
         $trimmed = trim($content);
         if (empty($trimmed)) {
@@ -97,10 +94,8 @@ class Fixer
 
     /**
      * @param string $content Basic content to fix
-     *
-     * @return string
      */
-    public function fixString($content)
+    public function fixString(string $content): string
     {
         foreach ($this->_rules as $fixer) {
             $content = $fixer->fix($content, $this->stateBag);
@@ -116,7 +111,7 @@ class Fixer
      *
      * @throws Exception\BadRuleSetException
      */
-    public function setRules($rules)
+    public function setRules(array $rules): void
     {
         $this->compileRules($rules);
     }
@@ -124,11 +119,9 @@ class Fixer
     /**
      * Customize the list of protected tags.
      *
-     * @param array $protectedTags
-     *
      * @throws \InvalidArgumentException
      */
-    public function setProtectedTags($protectedTags)
+    public function setProtectedTags(array $protectedTags): void
     {
         if (!\is_array($protectedTags)) {
             throw new \InvalidArgumentException('Protected tags must be an array (empty array for no protection).');
@@ -139,10 +132,8 @@ class Fixer
 
     /**
      * Get the current Locale tag.
-     *
-     * @return string
      */
-    public function getLocale()
+    public function getLocale(): string
     {
         return $this->locale;
     }
@@ -154,7 +145,7 @@ class Fixer
      *
      * @throws \InvalidArgumentException
      */
-    public function setLocale($locale)
+    public function setLocale(string $locale): void
     {
         if (!\is_string($locale) || empty($locale)) {
             throw new \InvalidArgumentException('Locale must be an IETF language tag.');
@@ -172,10 +163,8 @@ class Fixer
 
     /**
      * Get language part of a Locale string (fr_FR => fr).
-     *
-     * @return string
      */
-    public static function getLanguageFromLocale($locale)
+    public static function getLanguageFromLocale($locale): string
     {
         if (strpos($locale, '_')) {
             $parts = explode('_', $locale);
@@ -191,7 +180,7 @@ class Fixer
      *
      * @throws Exception\BadRuleSetException
      */
-    private function compileRules($rules)
+    private function compileRules(array $rules): void
     {
         if (!\is_array($rules) || empty($rules)) {
             throw new BadRuleSetException('Rules must be an array of Fixer');
@@ -228,7 +217,7 @@ class Fixer
     /**
      * Loop over all the DOMNode recursively.
      */
-    private function processDOM(\DOMNode $node, \DOMDocument $dom)
+    private function processDOM(\DOMNode $node, \DOMDocument $dom): void
     {
         if ($node->hasChildNodes()) {
             $nodes = [];
@@ -263,7 +252,7 @@ class Fixer
      * @param \DOMNode     $node      The parent node where to replace the current one
      * @param \DOMDocument $dom       The Document
      */
-    private function doFix(\DOMText $childNode, \DOMNode $node, \DOMDocument $dom)
+    private function doFix(\DOMText $childNode, \DOMNode $node, \DOMDocument $dom): void
     {
         $content = $childNode->wholeText;
         $current_node = new StateNode($childNode, $node, $dom);
@@ -286,11 +275,9 @@ class Fixer
     }
 
     /**
-     * @return \DOMDocument
-     *
      * @throws Exception\InvalidMarkupException
      */
-    private function loadDOMDocument($content)
+    private function loadDOMDocument($content): \DOMDocument
     {
         $dom = new \DOMDocument('1.0', 'UTF-8');
         $dom->encoding = 'UTF-8';
@@ -319,10 +306,8 @@ class Fixer
      *
      * @see http://php.net/manual/en/domdocument.loadhtml.php#91513
      * @see https://github.com/jolicode/JoliTypo/issues/7
-     *
-     * @return string
      */
-    private function fixContentEncoding($content)
+    private function fixContentEncoding($content): string
     {
         if (!empty($content)) {
             // Little hack to force UTF-8
@@ -361,10 +346,7 @@ class Fixer
         return $content;
     }
 
-    /**
-     * @return string
-     */
-    private function exportDOMDocument(\DOMDocument $dom)
+    private function exportDOMDocument(\DOMDocument $dom): string
     {
         // Remove added body & doctype
         $content = preg_replace(

--- a/src/JoliTypo/Fixer.php
+++ b/src/JoliTypo/Fixer.php
@@ -118,15 +118,9 @@ class Fixer
 
     /**
      * Customize the list of protected tags.
-     *
-     * @throws \InvalidArgumentException
      */
     public function setProtectedTags(array $protectedTags): void
     {
-        if (!\is_array($protectedTags)) {
-            throw new \InvalidArgumentException('Protected tags must be an array (empty array for no protection).');
-        }
-
         $this->protectedTags = $protectedTags;
     }
 
@@ -147,7 +141,7 @@ class Fixer
      */
     public function setLocale(string $locale): void
     {
-        if (!\is_string($locale) || empty($locale)) {
+        if (!$locale) {
             throw new \InvalidArgumentException('Locale must be an IETF language tag.');
         }
 
@@ -182,7 +176,7 @@ class Fixer
      */
     private function compileRules(array $rules): void
     {
-        if (!\is_array($rules) || empty($rules)) {
+        if (empty($rules)) {
             throw new BadRuleSetException('Rules must be an array of Fixer');
         }
 

--- a/src/JoliTypo/Fixer.php
+++ b/src/JoliTypo/Fixer.php
@@ -58,7 +58,7 @@ class Fixer
      */
     protected array $_rules = [];
 
-    protected StateBag $stateBag;
+    protected ?StateBag $stateBag = null;
 
     /**
      * @param array $rules Array of Fixer

--- a/src/JoliTypo/Fixer.php
+++ b/src/JoliTypo/Fixer.php
@@ -46,19 +46,19 @@ class Fixer
     /**
      * @var array HTML Tags to bypass
      */
-    protected array $protectedTags = ['head', 'link', 'pre', 'code', 'script', 'style'];
+    protected $protectedTags = ['head', 'link', 'pre', 'code', 'script', 'style'];
 
     /**
      * @var string The default locale (used by some Fixer)
      */
-    protected string $locale = 'en_GB';
+    protected $locale = 'en_GB';
 
     /**
      * @var array<FixerInterface> The rules Fixer instances to apply on each DOMText
      */
-    protected array $_rules = [];
+    protected $_rules = [];
 
-    protected ?StateBag $stateBag = null;
+    protected $stateBag = null;
 
     /**
      * @param array $rules Array of Fixer
@@ -73,7 +73,7 @@ class Fixer
      *
      * @return string Fixed content
      */
-    public function fix(string $content): string
+    public function fix(string $content)
     {
         $trimmed = trim($content);
         if (empty($trimmed)) {
@@ -93,7 +93,7 @@ class Fixer
     /**
      * @param string $content Basic content to fix
      */
-    public function fixString(string $content): string
+    public function fixString(string $content)
     {
         foreach ($this->_rules as $fixer) {
             $content = $fixer->fix($content, $this->stateBag);
@@ -109,7 +109,7 @@ class Fixer
      *
      * @throws Exception\BadRuleSetException
      */
-    public function setRules(array $rules): void
+    public function setRules(array $rules)
     {
         $this->compileRules($rules);
     }
@@ -117,7 +117,7 @@ class Fixer
     /**
      * Customize the list of protected tags.
      */
-    public function setProtectedTags(array $protectedTags): void
+    public function setProtectedTags(array $protectedTags)
     {
         $this->protectedTags = $protectedTags;
     }
@@ -125,7 +125,7 @@ class Fixer
     /**
      * Get the current Locale tag.
      */
-    public function getLocale(): string
+    public function getLocale()
     {
         return $this->locale;
     }
@@ -137,7 +137,7 @@ class Fixer
      *
      * @throws \InvalidArgumentException
      */
-    public function setLocale(string $locale): void
+    public function setLocale(string $locale)
     {
         if (!$locale) {
             throw new \InvalidArgumentException('Locale must be an IETF language tag.');
@@ -156,7 +156,7 @@ class Fixer
     /**
      * Get language part of a Locale string (fr_FR => fr).
      */
-    public static function getLanguageFromLocale($locale): string
+    public static function getLanguageFromLocale($locale)
     {
         if (strpos($locale, '_')) {
             $parts = explode('_', $locale);

--- a/src/JoliTypo/Fixer.php
+++ b/src/JoliTypo/Fixer.php
@@ -105,7 +105,7 @@ class Fixer
     /**
      * Change the list of rules for a given locale.
      * 
-     * @throws Exception\BadRuleSetException
+     * @throws BadRuleSetException
      */
     public function setRules(array $rules)
     {
@@ -168,7 +168,7 @@ class Fixer
     /**
      * Build the _rules array of Fixer.
      *
-     * @throws Exception\BadRuleSetException
+     * @throws BadRuleSetException
      */
     private function compileRules(array $rules): void
     {

--- a/src/JoliTypo/Fixer/BaseOpenClosePair.php
+++ b/src/JoliTypo/Fixer/BaseOpenClosePair.php
@@ -17,6 +17,9 @@ use JoliTypo\StateNode;
  */
 abstract class BaseOpenClosePair
 {
+    /**
+     * @return string
+     */
     protected function fixViaState(string $content, StateBag $stateBag, string $stateName, string $openRegexp, string $closeRegexp, string $openReplacement, string $closeReplacement)
     {
         $storedSibling = $stateBag->getSiblingNode($stateName);

--- a/src/JoliTypo/Fixer/BaseOpenClosePair.php
+++ b/src/JoliTypo/Fixer/BaseOpenClosePair.php
@@ -22,7 +22,7 @@ abstract class BaseOpenClosePair
         $storedSibling = $stateBag->getSiblingNode($stateName);
 
         // If no stored open quote node & open quote detected
-        if (false === $storedSibling && preg_match($openRegexp, $content)) {
+        if (null === $storedSibling && preg_match($openRegexp, $content)) {
             // Store the current node
             $stateBag->storeSiblingNode($stateName);
 

--- a/src/JoliTypo/Fixer/BaseOpenClosePair.php
+++ b/src/JoliTypo/Fixer/BaseOpenClosePair.php
@@ -17,7 +17,7 @@ use JoliTypo\StateNode;
  */
 abstract class BaseOpenClosePair
 {
-    protected function fixViaState(string $content, StateBag $stateBag, string $stateName, string $openRegexp, string $closeRegexp, string $openReplacement, string $closeReplacement): string
+    protected function fixViaState(string $content, StateBag $stateBag, string $stateName, string $openRegexp, string $closeRegexp, string $openReplacement, string $closeReplacement)
     {
         $storedSibling = $stateBag->getSiblingNode($stateName);
 

--- a/src/JoliTypo/Fixer/BaseOpenClosePair.php
+++ b/src/JoliTypo/Fixer/BaseOpenClosePair.php
@@ -17,7 +17,7 @@ use JoliTypo\StateNode;
  */
 abstract class BaseOpenClosePair
 {
-    protected function fixViaState($content, StateBag $stateBag, $stateName, $openRegexp, $closeRegexp, $openReplacement, $closeReplacement)
+    protected function fixViaState(string $content, StateBag $stateBag, string $stateName, string $openRegexp, string $closeRegexp, string $openReplacement, string $closeReplacement): string
     {
         $storedSibling = $stateBag->getSiblingNode($stateName);
 

--- a/src/JoliTypo/Fixer/CurlyQuote.php
+++ b/src/JoliTypo/Fixer/CurlyQuote.php
@@ -15,7 +15,7 @@ use JoliTypo\StateBag;
 
 class CurlyQuote implements FixerInterface
 {
-    public function fix(string $content, ?StateBag $stateBag = null): string
+    public function fix(string $content, ?StateBag $stateBag = null)
     {
         return preg_replace('@([a-z])\'@im', '$1' . Fixer::RSQUO, $content);
     }

--- a/src/JoliTypo/Fixer/CurlyQuote.php
+++ b/src/JoliTypo/Fixer/CurlyQuote.php
@@ -15,7 +15,7 @@ use JoliTypo\StateBag;
 
 class CurlyQuote implements FixerInterface
 {
-    public function fix($content, StateBag $stateBag = null)
+    public function fix(string $content, ?StateBag $stateBag): string
     {
         return preg_replace('@([a-z])\'@im', '$1' . Fixer::RSQUO, $content);
     }

--- a/src/JoliTypo/Fixer/CurlyQuote.php
+++ b/src/JoliTypo/Fixer/CurlyQuote.php
@@ -15,7 +15,7 @@ use JoliTypo\StateBag;
 
 class CurlyQuote implements FixerInterface
 {
-    public function fix(string $content, ?StateBag $stateBag): string
+    public function fix(string $content, ?StateBag $stateBag = null): string
     {
         return preg_replace('@([a-z])\'@im', '$1' . Fixer::RSQUO, $content);
     }

--- a/src/JoliTypo/Fixer/Dash.php
+++ b/src/JoliTypo/Fixer/Dash.php
@@ -15,7 +15,7 @@ use JoliTypo\StateBag;
 
 class Dash implements FixerInterface
 {
-    public function fix($content, StateBag $stateBag = null)
+    public function fix(string $content, ?StateBag $stateBag): string
     {
         $content = preg_replace('@(?<=[0-9 ]|^)-(?=[0-9 ]|$)@', Fixer::NDASH, $content);
 

--- a/src/JoliTypo/Fixer/Dash.php
+++ b/src/JoliTypo/Fixer/Dash.php
@@ -15,7 +15,7 @@ use JoliTypo\StateBag;
 
 class Dash implements FixerInterface
 {
-    public function fix(string $content, ?StateBag $stateBag): string
+    public function fix(string $content, ?StateBag $stateBag = null): string
     {
         $content = preg_replace('@(?<=[0-9 ]|^)-(?=[0-9 ]|$)@', Fixer::NDASH, $content);
 

--- a/src/JoliTypo/Fixer/Dash.php
+++ b/src/JoliTypo/Fixer/Dash.php
@@ -15,7 +15,7 @@ use JoliTypo\StateBag;
 
 class Dash implements FixerInterface
 {
-    public function fix(string $content, ?StateBag $stateBag = null): string
+    public function fix(string $content, ?StateBag $stateBag = null)
     {
         $content = preg_replace('@(?<=[0-9 ]|^)-(?=[0-9 ]|$)@', Fixer::NDASH, $content);
 

--- a/src/JoliTypo/Fixer/Dimension.php
+++ b/src/JoliTypo/Fixer/Dimension.php
@@ -15,7 +15,7 @@ use JoliTypo\StateBag;
 
 class Dimension implements FixerInterface
 {
-    public function fix($content, StateBag $stateBag = null)
+    public function fix(string $content, ?StateBag $stateBag): string
     {
         return preg_replace('@(\d+["\']?)(' . Fixer::ALL_SPACES . ')?x(' . Fixer::ALL_SPACES . ')?(?=\d)@', '$1$2' . Fixer::TIMES . '$2', $content);
     }

--- a/src/JoliTypo/Fixer/Dimension.php
+++ b/src/JoliTypo/Fixer/Dimension.php
@@ -15,7 +15,7 @@ use JoliTypo\StateBag;
 
 class Dimension implements FixerInterface
 {
-    public function fix(string $content, ?StateBag $stateBag = null): string
+    public function fix(string $content, ?StateBag $stateBag = null)
     {
         return preg_replace('@(\d+["\']?)(' . Fixer::ALL_SPACES . ')?x(' . Fixer::ALL_SPACES . ')?(?=\d)@', '$1$2' . Fixer::TIMES . '$2', $content);
     }

--- a/src/JoliTypo/Fixer/Dimension.php
+++ b/src/JoliTypo/Fixer/Dimension.php
@@ -15,7 +15,7 @@ use JoliTypo\StateBag;
 
 class Dimension implements FixerInterface
 {
-    public function fix(string $content, ?StateBag $stateBag): string
+    public function fix(string $content, ?StateBag $stateBag = null): string
     {
         return preg_replace('@(\d+["\']?)(' . Fixer::ALL_SPACES . ')?x(' . Fixer::ALL_SPACES . ')?(?=\d)@', '$1$2' . Fixer::TIMES . '$2', $content);
     }

--- a/src/JoliTypo/Fixer/Ellipsis.php
+++ b/src/JoliTypo/Fixer/Ellipsis.php
@@ -15,7 +15,7 @@ use JoliTypo\StateBag;
 
 class Ellipsis implements FixerInterface
 {
-    public function fix($content, StateBag $stateBag = null)
+    public function fix(string $content, ?StateBag $stateBag): string
     {
         return preg_replace('@\.{3,}@', Fixer::ELLIPSIS, $content);
     }

--- a/src/JoliTypo/Fixer/Ellipsis.php
+++ b/src/JoliTypo/Fixer/Ellipsis.php
@@ -15,7 +15,7 @@ use JoliTypo\StateBag;
 
 class Ellipsis implements FixerInterface
 {
-    public function fix(string $content, ?StateBag $stateBag): string
+    public function fix(string $content, ?StateBag $stateBag = null): string
     {
         return preg_replace('@\.{3,}@', Fixer::ELLIPSIS, $content);
     }

--- a/src/JoliTypo/Fixer/Ellipsis.php
+++ b/src/JoliTypo/Fixer/Ellipsis.php
@@ -15,7 +15,7 @@ use JoliTypo\StateBag;
 
 class Ellipsis implements FixerInterface
 {
-    public function fix(string $content, ?StateBag $stateBag = null): string
+    public function fix(string $content, ?StateBag $stateBag = null)
     {
         return preg_replace('@\.{3,}@', Fixer::ELLIPSIS, $content);
     }

--- a/src/JoliTypo/Fixer/FrenchNoBreakSpace.php
+++ b/src/JoliTypo/Fixer/FrenchNoBreakSpace.php
@@ -22,7 +22,7 @@ use JoliTypo\StateBag;
  */
 class FrenchNoBreakSpace implements FixerInterface
 {
-    public function fix(string $content, ?StateBag $stateBag = null): string
+    public function fix(string $content, ?StateBag $stateBag = null)
     {
         $content = preg_replace('@[' . Fixer::ALL_SPACES . ']+(:)@mu', Fixer::NO_BREAK_SPACE . '$1', $content);
         $content = preg_replace('@[' . Fixer::ALL_SPACES . ']+([;!\?])@mu', Fixer::NO_BREAK_THIN_SPACE . '$1', $content);

--- a/src/JoliTypo/Fixer/FrenchNoBreakSpace.php
+++ b/src/JoliTypo/Fixer/FrenchNoBreakSpace.php
@@ -22,7 +22,7 @@ use JoliTypo\StateBag;
  */
 class FrenchNoBreakSpace implements FixerInterface
 {
-    public function fix(string $content, ?StateBag $stateBag): string
+    public function fix(string $content, ?StateBag $stateBag = null): string
     {
         $content = preg_replace('@[' . Fixer::ALL_SPACES . ']+(:)@mu', Fixer::NO_BREAK_SPACE . '$1', $content);
         $content = preg_replace('@[' . Fixer::ALL_SPACES . ']+([;!\?])@mu', Fixer::NO_BREAK_THIN_SPACE . '$1', $content);

--- a/src/JoliTypo/Fixer/FrenchNoBreakSpace.php
+++ b/src/JoliTypo/Fixer/FrenchNoBreakSpace.php
@@ -22,7 +22,7 @@ use JoliTypo\StateBag;
  */
 class FrenchNoBreakSpace implements FixerInterface
 {
-    public function fix($content, StateBag $stateBag = null)
+    public function fix(string $content, ?StateBag $stateBag): string
     {
         $content = preg_replace('@[' . Fixer::ALL_SPACES . ']+(:)@mu', Fixer::NO_BREAK_SPACE . '$1', $content);
         $content = preg_replace('@[' . Fixer::ALL_SPACES . ']+([;!\?])@mu', Fixer::NO_BREAK_THIN_SPACE . '$1', $content);

--- a/src/JoliTypo/Fixer/FrenchQuotes.php
+++ b/src/JoliTypo/Fixer/FrenchQuotes.php
@@ -14,7 +14,7 @@ namespace JoliTypo\Fixer;
  */
 class FrenchQuotes extends SmartQuotes
 {
-    public function __construct(?string $locale)
+    public function __construct(?string $locale = null)
     {
         parent::__construct('fr');
     }

--- a/src/JoliTypo/Fixer/FrenchQuotes.php
+++ b/src/JoliTypo/Fixer/FrenchQuotes.php
@@ -14,7 +14,7 @@ namespace JoliTypo\Fixer;
  */
 class FrenchQuotes extends SmartQuotes
 {
-    public function __construct($locale = null)
+    public function __construct(?string $locale)
     {
         parent::__construct('fr');
     }

--- a/src/JoliTypo/Fixer/GermanQuotes.php
+++ b/src/JoliTypo/Fixer/GermanQuotes.php
@@ -14,7 +14,7 @@ namespace JoliTypo\Fixer;
  */
 class GermanQuotes extends SmartQuotes
 {
-    public function __construct($locale = null)
+    public function __construct(?string $locale)
     {
         parent::__construct('de');
     }

--- a/src/JoliTypo/Fixer/GermanQuotes.php
+++ b/src/JoliTypo/Fixer/GermanQuotes.php
@@ -14,7 +14,7 @@ namespace JoliTypo\Fixer;
  */
 class GermanQuotes extends SmartQuotes
 {
-    public function __construct(?string $locale)
+    public function __construct(?string $locale = null)
     {
         parent::__construct('de');
     }

--- a/src/JoliTypo/Fixer/Hyphen.php
+++ b/src/JoliTypo/Fixer/Hyphen.php
@@ -81,7 +81,7 @@ class Hyphen implements FixerInterface, LocaleAwareFixerInterface
 
     /**
      * Transform fr_FR to fr to fit the list of supported locales.
-     * 
+     *
      * @return void
      */
     protected function fixLocale(string $locale)

--- a/src/JoliTypo/Fixer/Hyphen.php
+++ b/src/JoliTypo/Fixer/Hyphen.php
@@ -17,15 +17,9 @@ use Org\Heigl\Hyphenator\Hyphenator;
 
 class Hyphen implements FixerInterface, LocaleAwareFixerInterface
 {
-    /**
-     * @var Hyphenator
-     */
-    private $hyphenator;
+    private Hyphenator $hyphenator;
 
-    /**
-     * @var array
-     */
-    private $supportedLocales = [
+    private array $supportedLocales = [
         'af_ZA',
         'ca',
         'da_DK',
@@ -53,7 +47,7 @@ class Hyphen implements FixerInterface, LocaleAwareFixerInterface
         'zu_ZA',
     ];
 
-    public function __construct($locale)
+    public function __construct(string $locale)
     {
         $this->setLocale($locale);
     }
@@ -69,7 +63,7 @@ class Hyphen implements FixerInterface, LocaleAwareFixerInterface
         return $this->hyphenator->hyphenate($content);
     }
 
-    protected function setOptions()
+    protected function setOptions(): void
     {
         $this->hyphenator->getOptions()->setHyphen(Fixer::SHY);
         $this->hyphenator->getOptions()->setLeftMin(4);
@@ -78,10 +72,8 @@ class Hyphen implements FixerInterface, LocaleAwareFixerInterface
 
     /**
      * Transform fr_FR to fr to fit the list of supported locales.
-     *
-     * @return mixed
      */
-    protected function fixLocale($locale)
+    protected function fixLocale(string $locale): string
     {
         if (\in_array($locale, $this->supportedLocales)) {
             return $locale;

--- a/src/JoliTypo/Fixer/Hyphen.php
+++ b/src/JoliTypo/Fixer/Hyphen.php
@@ -52,18 +52,18 @@ class Hyphen implements FixerInterface, LocaleAwareFixerInterface
         $this->setLocale($locale);
     }
 
-    public function setLocale(string $locale): void
+    public function setLocale(string $locale)
     {
         $this->hyphenator = Hyphenator::factory(null, $this->fixLocale($locale));
         $this->setOptions();
     }
 
-    public function fix(string $content, ?StateBag $stateBag = null): string
+    public function fix(string $content, ?StateBag $stateBag = null)
     {
         return $this->hyphenator->hyphenate($content);
     }
 
-    protected function setOptions(): void
+    protected function setOptions()
     {
         $this->hyphenator->getOptions()->setHyphen(Fixer::SHY);
         $this->hyphenator->getOptions()->setLeftMin(4);
@@ -73,7 +73,7 @@ class Hyphen implements FixerInterface, LocaleAwareFixerInterface
     /**
      * Transform fr_FR to fr to fit the list of supported locales.
      */
-    protected function fixLocale(string $locale): string
+    protected function fixLocale(string $locale)
     {
         if (\in_array($locale, $this->supportedLocales)) {
             return $locale;

--- a/src/JoliTypo/Fixer/Hyphen.php
+++ b/src/JoliTypo/Fixer/Hyphen.php
@@ -58,7 +58,7 @@ class Hyphen implements FixerInterface, LocaleAwareFixerInterface
         $this->setLocale($locale);
     }
 
-    public function setLocale($locale)
+    public function setLocale(string $locale): void
     {
         $this->hyphenator = Hyphenator::factory(null, $this->fixLocale($locale));
         $this->setOptions();

--- a/src/JoliTypo/Fixer/Hyphen.php
+++ b/src/JoliTypo/Fixer/Hyphen.php
@@ -52,17 +52,26 @@ class Hyphen implements FixerInterface, LocaleAwareFixerInterface
         $this->setLocale($locale);
     }
 
+    /**
+     * @return void
+     */
     public function setLocale(string $locale)
     {
         $this->hyphenator = Hyphenator::factory(null, $this->fixLocale($locale));
         $this->setOptions();
     }
 
+    /**
+     * @return string
+     */
     public function fix(string $content, ?StateBag $stateBag = null)
     {
         return $this->hyphenator->hyphenate($content);
     }
 
+    /**
+     * @return void
+     */
     protected function setOptions()
     {
         $this->hyphenator->getOptions()->setHyphen(Fixer::SHY);
@@ -72,6 +81,8 @@ class Hyphen implements FixerInterface, LocaleAwareFixerInterface
 
     /**
      * Transform fr_FR to fr to fit the list of supported locales.
+     * 
+     * @return void
      */
     protected function fixLocale(string $locale)
     {

--- a/src/JoliTypo/Fixer/Hyphen.php
+++ b/src/JoliTypo/Fixer/Hyphen.php
@@ -82,7 +82,7 @@ class Hyphen implements FixerInterface, LocaleAwareFixerInterface
     /**
      * Transform fr_FR to fr to fit the list of supported locales.
      *
-     * @return void
+     * @return string
      */
     protected function fixLocale(string $locale)
     {

--- a/src/JoliTypo/Fixer/Hyphen.php
+++ b/src/JoliTypo/Fixer/Hyphen.php
@@ -64,7 +64,7 @@ class Hyphen implements FixerInterface, LocaleAwareFixerInterface
         $this->setOptions();
     }
 
-    public function fix($content, StateBag $stateBag = null)
+    public function fix(string $content, ?StateBag $stateBag): string
     {
         return $this->hyphenator->hyphenate($content);
     }

--- a/src/JoliTypo/Fixer/Hyphen.php
+++ b/src/JoliTypo/Fixer/Hyphen.php
@@ -58,7 +58,7 @@ class Hyphen implements FixerInterface, LocaleAwareFixerInterface
         $this->setOptions();
     }
 
-    public function fix(string $content, ?StateBag $stateBag): string
+    public function fix(string $content, ?StateBag $stateBag = null): string
     {
         return $this->hyphenator->hyphenate($content);
     }

--- a/src/JoliTypo/Fixer/NoSpaceBeforeComma.php
+++ b/src/JoliTypo/Fixer/NoSpaceBeforeComma.php
@@ -18,7 +18,7 @@ use JoliTypo\StateBag;
  */
 class NoSpaceBeforeComma implements FixerInterface
 {
-    public function fix($content, StateBag $stateBag = null)
+    public function fix(string $content, ?StateBag $stateBag): string
     {
         return preg_replace('@([^\d\s]+)[' . Fixer::ALL_SPACES . ']*(,)[' . Fixer::ALL_SPACES . ']*@mu', '$1$2 ', $content);
     }

--- a/src/JoliTypo/Fixer/NoSpaceBeforeComma.php
+++ b/src/JoliTypo/Fixer/NoSpaceBeforeComma.php
@@ -18,7 +18,7 @@ use JoliTypo\StateBag;
  */
 class NoSpaceBeforeComma implements FixerInterface
 {
-    public function fix(string $content, ?StateBag $stateBag): string
+    public function fix(string $content, ?StateBag $stateBag = null): string
     {
         return preg_replace('@([^\d\s]+)[' . Fixer::ALL_SPACES . ']*(,)[' . Fixer::ALL_SPACES . ']*@mu', '$1$2 ', $content);
     }

--- a/src/JoliTypo/Fixer/NoSpaceBeforeComma.php
+++ b/src/JoliTypo/Fixer/NoSpaceBeforeComma.php
@@ -18,7 +18,7 @@ use JoliTypo\StateBag;
  */
 class NoSpaceBeforeComma implements FixerInterface
 {
-    public function fix(string $content, ?StateBag $stateBag = null): string
+    public function fix(string $content, ?StateBag $stateBag = null)
     {
         return preg_replace('@([^\d\s]+)[' . Fixer::ALL_SPACES . ']*(,)[' . Fixer::ALL_SPACES . ']*@mu', '$1$2 ', $content);
     }

--- a/src/JoliTypo/Fixer/SmartQuotes.php
+++ b/src/JoliTypo/Fixer/SmartQuotes.php
@@ -27,7 +27,7 @@ class SmartQuotes extends BaseOpenClosePair implements FixerInterface, LocaleAwa
         $this->setLocale($locale);
     }
 
-    public function fix(string $content, ?StateBag $stateBag): string
+    public function fix(string $content, ?StateBag $stateBag = null): string
     {
         if (!$this->opening || !$this->closing) {
             throw new BadFixerConfigurationException();

--- a/src/JoliTypo/Fixer/SmartQuotes.php
+++ b/src/JoliTypo/Fixer/SmartQuotes.php
@@ -17,17 +17,32 @@ use JoliTypo\StateBag;
 
 class SmartQuotes extends BaseOpenClosePair implements FixerInterface, LocaleAwareFixerInterface
 {
-    protected string $opening       = '';
-    protected string $openingSuffix = '';
-    protected string $closing       = '';
-    protected string $closingPrefix = '';
+    /**
+     * @var string
+     */
+    protected $opening = '';
+
+    /**
+     * @var string
+     */
+    protected $openingSuffix = '';
+
+    /**
+     * @var string
+     */
+    protected $closing = '';
+
+    /**
+     * @var string
+     */
+    protected $closingPrefix = '';
 
     public function __construct(string $locale)
     {
         $this->setLocale($locale);
     }
 
-    public function fix(string $content, ?StateBag $stateBag = null): string
+    public function fix(string $content, ?StateBag $stateBag = null)
     {
         if (!$this->opening || !$this->closing) {
             throw new BadFixerConfigurationException();
@@ -57,7 +72,7 @@ class SmartQuotes extends BaseOpenClosePair implements FixerInterface, LocaleAwa
     /**
      * Default configuration for supported lang.
      */
-    public function setLocale(string $locale): void
+    public function setLocale(string $locale)
     {
         // Handle from locale + country
         switch (strtolower($locale)) {
@@ -164,22 +179,22 @@ class SmartQuotes extends BaseOpenClosePair implements FixerInterface, LocaleAwa
         }
     }
 
-    public function setOpening(string $opening): void
+    public function setOpening(string $opening)
     {
         $this->opening = $opening;
     }
 
-    public function setOpeningSuffix(string $openingSuffix): void
+    public function setOpeningSuffix(string $openingSuffix)
     {
         $this->openingSuffix = $openingSuffix;
     }
 
-    public function setClosing(string $closing): void
+    public function setClosing(string $closing)
     {
         $this->closing = $closing;
     }
 
-    public function setClosingPrefix(string $closingPrefix): void
+    public function setClosingPrefix(string $closingPrefix)
     {
         $this->closingPrefix = $closingPrefix;
     }

--- a/src/JoliTypo/Fixer/SmartQuotes.php
+++ b/src/JoliTypo/Fixer/SmartQuotes.php
@@ -17,9 +17,9 @@ use JoliTypo\StateBag;
 
 class SmartQuotes extends BaseOpenClosePair implements FixerInterface, LocaleAwareFixerInterface
 {
-    protected string $opening;
+    protected string $opening       = '';
     protected string $openingSuffix = '';
-    protected string $closing;
+    protected string $closing       = '';
     protected string $closingPrefix = '';
 
     public function __construct(string $locale)

--- a/src/JoliTypo/Fixer/SmartQuotes.php
+++ b/src/JoliTypo/Fixer/SmartQuotes.php
@@ -17,12 +17,12 @@ use JoliTypo\StateBag;
 
 class SmartQuotes extends BaseOpenClosePair implements FixerInterface, LocaleAwareFixerInterface
 {
-    protected $opening;
-    protected $openingSuffix = '';
-    protected $closing;
-    protected $closingPrefix = '';
+    protected string $opening;
+    protected string $openingSuffix = '';
+    protected string $closing;
+    protected string $closingPrefix = '';
 
-    public function __construct($locale)
+    public function __construct(string $locale)
     {
         $this->setLocale($locale);
     }
@@ -164,34 +164,22 @@ class SmartQuotes extends BaseOpenClosePair implements FixerInterface, LocaleAwa
         }
     }
 
-    /**
-     * @param string $opening
-     */
-    public function setOpening($opening)
+    public function setOpening(string $opening): void
     {
         $this->opening = $opening;
     }
 
-    /**
-     * @param string $openingSuffix
-     */
-    public function setOpeningSuffix($openingSuffix)
+    public function setOpeningSuffix(string $openingSuffix): void
     {
         $this->openingSuffix = $openingSuffix;
     }
 
-    /**
-     * @param string $closing
-     */
-    public function setClosing($closing)
+    public function setClosing(string $closing): void
     {
         $this->closing = $closing;
     }
 
-    /**
-     * @param string $closingPrefix
-     */
-    public function setClosingPrefix($closingPrefix)
+    public function setClosingPrefix(string $closingPrefix): void
     {
         $this->closingPrefix = $closingPrefix;
     }

--- a/src/JoliTypo/Fixer/SmartQuotes.php
+++ b/src/JoliTypo/Fixer/SmartQuotes.php
@@ -27,7 +27,7 @@ class SmartQuotes extends BaseOpenClosePair implements FixerInterface, LocaleAwa
         $this->setLocale($locale);
     }
 
-    public function fix($content, StateBag $stateBag = null)
+    public function fix(string $content, ?StateBag $stateBag): string
     {
         if (!$this->opening || !$this->closing) {
             throw new BadFixerConfigurationException();

--- a/src/JoliTypo/Fixer/SmartQuotes.php
+++ b/src/JoliTypo/Fixer/SmartQuotes.php
@@ -179,21 +179,33 @@ class SmartQuotes extends BaseOpenClosePair implements FixerInterface, LocaleAwa
         }
     }
 
+    /**
+     * @return void
+     */
     public function setOpening(string $opening)
     {
         $this->opening = $opening;
     }
 
+    /**
+     * @return void
+     */
     public function setOpeningSuffix(string $openingSuffix)
     {
         $this->openingSuffix = $openingSuffix;
     }
 
+    /**
+     * @return void
+     */
     public function setClosing(string $closing)
     {
         $this->closing = $closing;
     }
 
+    /**
+     * @return void
+     */
     public function setClosingPrefix(string $closingPrefix)
     {
         $this->closingPrefix = $closingPrefix;

--- a/src/JoliTypo/Fixer/SmartQuotes.php
+++ b/src/JoliTypo/Fixer/SmartQuotes.php
@@ -56,10 +56,8 @@ class SmartQuotes extends BaseOpenClosePair implements FixerInterface, LocaleAwa
 
     /**
      * Default configuration for supported lang.
-     *
-     * @param string $locale
      */
-    public function setLocale($locale)
+    public function setLocale(string $locale): void
     {
         // Handle from locale + country
         switch (strtolower($locale)) {

--- a/src/JoliTypo/Fixer/Trademark.php
+++ b/src/JoliTypo/Fixer/Trademark.php
@@ -15,7 +15,7 @@ use JoliTypo\StateBag;
 
 class Trademark implements FixerInterface
 {
-    public function fix(string $content, ?StateBag $stateBag = null): string
+    public function fix(string $content, ?StateBag $stateBag = null)
     {
         $content = preg_replace('@\(tm\)@i', Fixer::TRADE, $content);
         $content = preg_replace('@\(c\)[' . Fixer::ALL_SPACES . ']([0-9]+)@i', Fixer::COPY . Fixer::NO_BREAK_SPACE . '$1', $content);

--- a/src/JoliTypo/Fixer/Trademark.php
+++ b/src/JoliTypo/Fixer/Trademark.php
@@ -15,7 +15,7 @@ use JoliTypo\StateBag;
 
 class Trademark implements FixerInterface
 {
-    public function fix(string $content, ?StateBag $stateBag): string
+    public function fix(string $content, ?StateBag $stateBag = null): string
     {
         $content = preg_replace('@\(tm\)@i', Fixer::TRADE, $content);
         $content = preg_replace('@\(c\)[' . Fixer::ALL_SPACES . ']([0-9]+)@i', Fixer::COPY . Fixer::NO_BREAK_SPACE . '$1', $content);

--- a/src/JoliTypo/Fixer/Trademark.php
+++ b/src/JoliTypo/Fixer/Trademark.php
@@ -15,7 +15,7 @@ use JoliTypo\StateBag;
 
 class Trademark implements FixerInterface
 {
-    public function fix($content, StateBag $stateBag = null)
+    public function fix(string $content, ?StateBag $stateBag): string
     {
         $content = preg_replace('@\(tm\)@i', Fixer::TRADE, $content);
         $content = preg_replace('@\(c\)[' . Fixer::ALL_SPACES . ']([0-9]+)@i', Fixer::COPY . Fixer::NO_BREAK_SPACE . '$1', $content);

--- a/src/JoliTypo/Fixer/Unit.php
+++ b/src/JoliTypo/Fixer/Unit.php
@@ -18,7 +18,7 @@ use JoliTypo\StateBag;
  */
 class Unit implements FixerInterface
 {
-    public function fix(string $content, ?StateBag $stateBag): string
+    public function fix(string $content, ?StateBag $stateBag = null): string
     {
         // Support a wide range of currencies
         return preg_replace('@([\dº])(' . Fixer::ALL_SPACES . ')+([º°%Ω฿₵¢₡$₫֏€ƒ₲₴₭£₤₺₦₨₱៛₹$₪৳₸₮₩¥\w]{1})@', '$1' . Fixer::NO_BREAK_SPACE . '$3', $content);

--- a/src/JoliTypo/Fixer/Unit.php
+++ b/src/JoliTypo/Fixer/Unit.php
@@ -18,7 +18,7 @@ use JoliTypo\StateBag;
  */
 class Unit implements FixerInterface
 {
-    public function fix(string $content, ?StateBag $stateBag = null): string
+    public function fix(string $content, ?StateBag $stateBag = null)
     {
         // Support a wide range of currencies
         return preg_replace('@([\dº])(' . Fixer::ALL_SPACES . ')+([º°%Ω฿₵¢₡$₫֏€ƒ₲₴₭£₤₺₦₨₱៛₹$₪৳₸₮₩¥\w]{1})@', '$1' . Fixer::NO_BREAK_SPACE . '$3', $content);

--- a/src/JoliTypo/Fixer/Unit.php
+++ b/src/JoliTypo/Fixer/Unit.php
@@ -18,7 +18,7 @@ use JoliTypo\StateBag;
  */
 class Unit implements FixerInterface
 {
-    public function fix($content, StateBag $stateBag = null)
+    public function fix(string $content, ?StateBag $stateBag): string
     {
         // Support a wide range of currencies
         return preg_replace('@([\dº])(' . Fixer::ALL_SPACES . ')+([º°%Ω฿₵¢₡$₫֏€ƒ₲₴₭£₤₺₦₨₱៛₹$₪৳₸₮₩¥\w]{1})@', '$1' . Fixer::NO_BREAK_SPACE . '$3', $content);

--- a/src/JoliTypo/FixerInterface.php
+++ b/src/JoliTypo/FixerInterface.php
@@ -11,9 +11,5 @@ namespace JoliTypo;
 
 interface FixerInterface
 {
-    /**
-     * @param string        $content  A string to fix
-     * @param StateBag|null $stateBag A bag of useful information
-     */
     public function fix(string $content, ?StateBag $stateBag = null);
 }

--- a/src/JoliTypo/FixerInterface.php
+++ b/src/JoliTypo/FixerInterface.php
@@ -15,5 +15,5 @@ interface FixerInterface
      * @param string        $content  A string to fix
      * @param StateBag|null $stateBag A bag of useful information
      */
-    public function fix(string $content, ?StateBag $stateBag): string;
+    public function fix(string $content, ?StateBag $stateBag = null): string;
 }

--- a/src/JoliTypo/FixerInterface.php
+++ b/src/JoliTypo/FixerInterface.php
@@ -11,5 +11,8 @@ namespace JoliTypo;
 
 interface FixerInterface
 {
+    /**
+     * @return string
+     */
     public function fix(string $content, ?StateBag $stateBag = null);
 }

--- a/src/JoliTypo/FixerInterface.php
+++ b/src/JoliTypo/FixerInterface.php
@@ -12,10 +12,8 @@ namespace JoliTypo;
 interface FixerInterface
 {
     /**
-     * @param string   $content  A string to fix
-     * @param StateBag $stateBag A bag of useful information
-     *
-     * @return string
+     * @param string        $content  A string to fix
+     * @param StateBag|null $stateBag A bag of useful information
      */
-    public function fix($content, StateBag $stateBag = null);
+    public function fix(string $content, ?StateBag $stateBag): string;
 }

--- a/src/JoliTypo/FixerInterface.php
+++ b/src/JoliTypo/FixerInterface.php
@@ -15,5 +15,5 @@ interface FixerInterface
      * @param string        $content  A string to fix
      * @param StateBag|null $stateBag A bag of useful information
      */
-    public function fix(string $content, ?StateBag $stateBag = null): string;
+    public function fix(string $content, ?StateBag $stateBag = null);
 }

--- a/src/JoliTypo/LocaleAwareFixerInterface.php
+++ b/src/JoliTypo/LocaleAwareFixerInterface.php
@@ -11,8 +11,5 @@ namespace JoliTypo;
 
 interface LocaleAwareFixerInterface
 {
-    /**
-     * @param string $locale
-     */
-    public function setLocale($locale);
+    public function setLocale(string $locale): void;
 }

--- a/src/JoliTypo/LocaleAwareFixerInterface.php
+++ b/src/JoliTypo/LocaleAwareFixerInterface.php
@@ -11,5 +11,8 @@ namespace JoliTypo;
 
 interface LocaleAwareFixerInterface
 {
+    /**
+     * @return void
+     */
     public function setLocale(string $locale);
 }

--- a/src/JoliTypo/LocaleAwareFixerInterface.php
+++ b/src/JoliTypo/LocaleAwareFixerInterface.php
@@ -11,5 +11,5 @@ namespace JoliTypo;
 
 interface LocaleAwareFixerInterface
 {
-    public function setLocale(string $locale): void;
+    public function setLocale(string $locale);
 }

--- a/src/JoliTypo/StateBag.php
+++ b/src/JoliTypo/StateBag.php
@@ -11,48 +11,32 @@ namespace JoliTypo;
 
 class StateBag
 {
-    /**
-     * @var int
-     */
-    protected $currentDepth = 0;
+    protected int $currentDepth = 0;
 
-    /**
-     * @var StateNode
-     */
-    protected $currentNode;
+    protected StateNode $currentNode;
 
     /**
      * @var array<StateNode>
      */
-    protected $siblingNode = [];
+    protected array $siblingNode = [];
 
     /**
      * Save the current StateNode, edit MAY be done to it later.
-     *
-     * @param string $key
      */
-    public function storeSiblingNode($key)
+    public function storeSiblingNode(string $key): void
     {
         $this->siblingNode[$key][$this->currentDepth] = $this->currentNode;
     }
 
-    /**
-     * @param string $key
-     *
-     * @return bool|StateNode
-     */
-    public function getSiblingNode($key)
+    public function getSiblingNode(string $key): ?StateNode
     {
-        return $this->siblingNode[$key][$this->currentDepth] ?? false;
+        return $this->siblingNode[$key][$this->currentDepth] ?? null;
     }
 
     /**
      * Replace and destroy the content of a stored Node.
-     *
-     * @param string $key
-     * @param string $new_content
      */
-    public function fixSiblingNode($key, $new_content)
+    public function fixSiblingNode(string $key, string $new_content): void
     {
         $storedSibling = $this->getSiblingNode($key);
 
@@ -62,26 +46,17 @@ class StateBag
         }
     }
 
-    /**
-     * @param \JoliTypo\StateNode $currentNode
-     */
-    public function setCurrentNode(StateNode $currentNode)
+    public function setCurrentNode(StateNode $currentNode): void
     {
         $this->currentNode = $currentNode;
     }
 
-    /**
-     * @param int $currentDepth
-     */
-    public function setCurrentDepth($currentDepth)
+    public function setCurrentDepth(int $currentDepth): void
     {
         $this->currentDepth = $currentDepth;
     }
 
-    /**
-     * @return int
-     */
-    public function getCurrentDepth()
+    public function getCurrentDepth(): int
     {
         return $this->currentDepth;
     }

--- a/src/JoliTypo/StateBag.php
+++ b/src/JoliTypo/StateBag.php
@@ -28,7 +28,7 @@ class StateBag
 
     /**
      * Save the current StateNode, edit MAY be done to it later.
-     * 
+     *
      * @return void
      */
     public function storeSiblingNode(string $key)
@@ -46,7 +46,7 @@ class StateBag
 
     /**
      * Replace and destroy the content of a stored Node.
-     * 
+     *
      * @return void
      */
     public function fixSiblingNode(string $key, string $new_content)

--- a/src/JoliTypo/StateBag.php
+++ b/src/JoliTypo/StateBag.php
@@ -28,12 +28,17 @@ class StateBag
 
     /**
      * Save the current StateNode, edit MAY be done to it later.
+     * 
+     * @return void
      */
     public function storeSiblingNode(string $key)
     {
         $this->siblingNode[$key][$this->currentDepth] = $this->currentNode;
     }
 
+    /**
+     * @return StateNode|null
+     */
     public function getSiblingNode(string $key)
     {
         return $this->siblingNode[$key][$this->currentDepth] ?? null;
@@ -41,6 +46,8 @@ class StateBag
 
     /**
      * Replace and destroy the content of a stored Node.
+     * 
+     * @return void
      */
     public function fixSiblingNode(string $key, string $new_content)
     {
@@ -52,16 +59,25 @@ class StateBag
         }
     }
 
+    /**
+     * @return void
+     */
     public function setCurrentNode(StateNode $currentNode)
     {
         $this->currentNode = $currentNode;
     }
 
+    /**
+     * @return void
+     */
     public function setCurrentDepth(int $currentDepth)
     {
         $this->currentDepth = $currentDepth;
     }
 
+    /**
+     * @return int
+     */
     public function getCurrentDepth()
     {
         return $this->currentDepth;

--- a/src/JoliTypo/StateBag.php
+++ b/src/JoliTypo/StateBag.php
@@ -11,24 +11,30 @@ namespace JoliTypo;
 
 class StateBag
 {
-    protected int $currentDepth = 0;
+    /**
+     * @var int
+     */
+    protected $currentDepth = 0;
 
-    protected StateNode $currentNode;
+    /**
+     * @var StateNode
+     */
+    protected $currentNode;
 
     /**
      * @var array<StateNode>
      */
-    protected array $siblingNode = [];
+    protected $siblingNode = [];
 
     /**
      * Save the current StateNode, edit MAY be done to it later.
      */
-    public function storeSiblingNode(string $key): void
+    public function storeSiblingNode(string $key)
     {
         $this->siblingNode[$key][$this->currentDepth] = $this->currentNode;
     }
 
-    public function getSiblingNode(string $key): ?StateNode
+    public function getSiblingNode(string $key)
     {
         return $this->siblingNode[$key][$this->currentDepth] ?? null;
     }
@@ -36,7 +42,7 @@ class StateBag
     /**
      * Replace and destroy the content of a stored Node.
      */
-    public function fixSiblingNode(string $key, string $new_content): void
+    public function fixSiblingNode(string $key, string $new_content)
     {
         $storedSibling = $this->getSiblingNode($key);
 
@@ -46,17 +52,17 @@ class StateBag
         }
     }
 
-    public function setCurrentNode(StateNode $currentNode): void
+    public function setCurrentNode(StateNode $currentNode)
     {
         $this->currentNode = $currentNode;
     }
 
-    public function setCurrentDepth(int $currentDepth): void
+    public function setCurrentDepth(int $currentDepth)
     {
         $this->currentDepth = $currentDepth;
     }
 
-    public function getCurrentDepth(): int
+    public function getCurrentDepth()
     {
         return $this->currentDepth;
     }

--- a/src/JoliTypo/StateNode.php
+++ b/src/JoliTypo/StateNode.php
@@ -11,20 +11,9 @@ namespace JoliTypo;
 
 class StateNode
 {
-    /**
-     * @var \DOMText
-     */
-    private $node;
-
-    /**
-     * @var \DOMNode
-     */
-    private $parent;
-
-    /**
-     * @var \DOMDocument
-     */
-    private $document;
+    private \DOMText $node;
+    private \DOMNode $parent;
+    private \DOMDocument $document;
 
     public function __construct(\DOMText $node, \DOMNode $parent, \DOMDocument $document)
     {
@@ -33,34 +22,22 @@ class StateNode
         $this->document = $document;
     }
 
-    /**
-     * @return \DOMText
-     */
-    public function getNode()
+    public function getNode(): \DOMText
     {
         return $this->node;
     }
 
-    /**
-     * @return \DOMNode
-     */
-    public function getParent()
+    public function getParent(): \DOMNode
     {
         return $this->parent;
     }
 
-    /**
-     * @return \DOMDocument
-     */
-    public function getDocument()
+    public function getDocument(): \DOMDocument
     {
         return $this->document;
     }
 
-    /**
-     * @param \DOMText $node
-     */
-    public function replaceNode($node)
+    public function replaceNode(\DOMText $node): void
     {
         $this->node = $node;
     }

--- a/tests/JoliTypo/Tests/Bridge/FunctionalTest.php
+++ b/tests/JoliTypo/Tests/Bridge/FunctionalTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 class FunctionalTest extends TestCase
 {
-    public function testRenderTwigViaFilter()
+    public function testRenderTwigViaFilter(): void
     {
         $kernel = new AppKernel('prod', false);
         $kernel->boot();

--- a/tests/JoliTypo/Tests/Bridge/app/AppController.php
+++ b/tests/JoliTypo/Tests/Bridge/app/AppController.php
@@ -14,14 +14,14 @@ use Twig\Environment;
 
 class AppController
 {
-    private $twig;
+    private Environment $twig;
 
     public function __construct(Environment $twig)
     {
         $this->twig = $twig;
     }
 
-    public function fixAction()
+    public function fixAction(): Response
     {
         if (1 === $this->twig::MAJOR_VERSION) {
             $template = $this->twig->createTemplate(

--- a/tests/JoliTypo/Tests/EnglishTest.php
+++ b/tests/JoliTypo/Tests/EnglishTest.php
@@ -39,7 +39,7 @@ class EnglishTest extends TestCase
         FIXED;
     private $en_fixers = ['Unit', 'Ellipsis', 'Dimension', 'Dash', 'SmartQuotes', 'CurlyQuote', 'Hyphen', 'Trademark'];
 
-    public function testFixFullText()
+    public function testFixFullText(): void
     {
         $fixer = new Fixer($this->en_fixers);
         $this->assertInstanceOf('JoliTypo\Fixer', $fixer);
@@ -47,7 +47,7 @@ class EnglishTest extends TestCase
         $this->assertSame(self::FIXED, $fixer->fix(self::TOFIX));
     }
 
-    public function testReadMeExemple()
+    public function testReadMeExemple(): void
     {
         $before = <<<'HTML'
             <p>"Tell me Mr. Anderson... what good is a phone call... if you're unable to speak?" -- Agent Smith, <em>Matrix</em>.</p>
@@ -62,7 +62,7 @@ class EnglishTest extends TestCase
         $this->assertSame($after, $fixer->fix($before));
     }
 
-    public function testDoubleQuoteMess()
+    public function testDoubleQuoteMess(): void
     {
         $fixed = <<<'HTML'
             <p>I&rsquo;m learning &ldquo;<a href="http://composer.json.jolicode.com">composer.json</a>&rdquo; as it&rsquo;s better than a &ldquo;.docx&rdquo;</p>
@@ -77,7 +77,7 @@ class EnglishTest extends TestCase
         $this->assertSame($fixed, $fixer->fix($to_fix));
     }
 
-    public function testHtmlHeart()
+    public function testHtmlHeart(): void
     {
         $fixed = <<<'HTML'
             <p>We &lt;3&nbsp;web.</p>

--- a/tests/JoliTypo/Tests/Fixer/CurlyQuoteTest.php
+++ b/tests/JoliTypo/Tests/Fixer/CurlyQuoteTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 class CurlyQuoteTest extends TestCase
 {
-    public function testSimpleString()
+    public function testSimpleString(): void
     {
         $fixer = new Fixer\CurlyQuote();
         $this->assertInstanceOf('JoliTypo\Fixer\CurlyQuote', $fixer);
@@ -26,7 +26,7 @@ class CurlyQuoteTest extends TestCase
         $this->assertSame('Qu’est ce que l’univers ?', $fixer->fix("Qu'est ce que l'univers ?"));
     }
 
-    public function testFalsePositives()
+    public function testFalsePositives(): void
     {
         $fixer = new Fixer\CurlyQuote();
 

--- a/tests/JoliTypo/Tests/Fixer/DashTest.php
+++ b/tests/JoliTypo/Tests/Fixer/DashTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 class DashTest extends TestCase
 {
-    public function testSimpleString()
+    public function testSimpleString(): void
     {
         $fixer = new Fixer\Dash();
         $this->assertInstanceOf('JoliTypo\Fixer\Dash', $fixer);

--- a/tests/JoliTypo/Tests/Fixer/DimensionTest.php
+++ b/tests/JoliTypo/Tests/Fixer/DimensionTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 class DimensionTest extends TestCase
 {
-    public function testSimpleString()
+    public function testSimpleString(): void
     {
         $fixer = new Fixer\Dimension();
         $this->assertInstanceOf('JoliTypo\Fixer\Dimension', $fixer);

--- a/tests/JoliTypo/Tests/Fixer/EllipsisTest.php
+++ b/tests/JoliTypo/Tests/Fixer/EllipsisTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 class EllipsisTest extends TestCase
 {
-    public function testSimpleString()
+    public function testSimpleString(): void
     {
         $fixer = new Fixer\Ellipsis();
         $this->assertInstanceOf('JoliTypo\Fixer\Ellipsis', $fixer);

--- a/tests/JoliTypo/Tests/Fixer/EnglishQuotesTest.php
+++ b/tests/JoliTypo/Tests/Fixer/EnglishQuotesTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 class EnglishQuotesTest extends TestCase
 {
-    public function testSimpleString()
+    public function testSimpleString(): void
     {
         $fixer = new Fixer\EnglishQuotes();
         $this->assertInstanceOf('JoliTypo\Fixer\EnglishQuotes', $fixer);
@@ -22,14 +22,14 @@ class EnglishQuotesTest extends TestCase
         $this->basicStringsAsserts($fixer);
     }
 
-    public function testSmartQuoteConfig()
+    public function testSmartQuoteConfig(): void
     {
         $fixer = new Fixer\SmartQuotes('en');
 
         $this->basicStringsAsserts($fixer);
     }
 
-    public function testFalsePositives()
+    public function testFalsePositives(): void
     {
         $fixer = new Fixer\EnglishQuotes();
 
@@ -37,7 +37,7 @@ class EnglishQuotesTest extends TestCase
         $this->assertSame('2"44\'.', $fixer->fix('2"44\'.'));
     }
 
-    protected function basicStringsAsserts($fixer)
+    protected function basicStringsAsserts($fixer): void
     {
         $this->assertSame('“I am smart”', $fixer->fix('"I am smart"'));
         $this->assertSame('Quote say: “I am smart”', $fixer->fix('Quote say: "I am smart"'));

--- a/tests/JoliTypo/Tests/Fixer/FrenchNoBreakSpaceTest.php
+++ b/tests/JoliTypo/Tests/Fixer/FrenchNoBreakSpaceTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 class FrenchNoBreakSpaceTest extends TestCase
 {
-    public function testSimpleString()
+    public function testSimpleString(): void
     {
         $fixer = new Fixer\FrenchNoBreakSpace();
         $this->assertInstanceOf('JoliTypo\Fixer\FrenchNoBreakSpace', $fixer);

--- a/tests/JoliTypo/Tests/Fixer/FrenchQuotesTest.php
+++ b/tests/JoliTypo/Tests/Fixer/FrenchQuotesTest.php
@@ -10,11 +10,12 @@
 namespace JoliTypo\Tests\Fixer;
 
 use JoliTypo\Fixer;
+use JoliTypo\FixerInterface;
 use PHPUnit\Framework\TestCase;
 
 class FrenchQuotesTest extends TestCase
 {
-    public function testSimpleString()
+    public function testSimpleString(): void
     {
         $fixer = new Fixer\FrenchQuotes();
         $this->assertInstanceOf('JoliTypo\Fixer\FrenchQuotes', $fixer);
@@ -22,13 +23,13 @@ class FrenchQuotesTest extends TestCase
         $this->basicStringsAsserts($fixer);
     }
 
-    public function testSmartQuoteFrenchConfig()
+    public function testSmartQuoteFrenchConfig(): void
     {
         $fixer = new Fixer\SmartQuotes('fr_FR');
         $this->basicStringsAsserts($fixer);
     }
 
-    public function testFalsePositives()
+    public function testFalsePositives(): void
     {
         $fixer = new Fixer\FrenchQuotes();
 
@@ -38,7 +39,7 @@ class FrenchQuotesTest extends TestCase
     /**
      * :-( :sadface:.
      */
-    public function testImpossible()
+    public function testImpossible(): void
     {
         $this->markTestSkipped("Those tests can't pass: they are edge case JoliTypo does not cover ATM. Feel free to fix!");
 
@@ -47,7 +48,7 @@ class FrenchQuotesTest extends TestCase
         $this->assertSame('Oh my god, this quote is alone: " ! But those are «' . Fixer::NO_BREAK_SPACE . 'ok' . Fixer::NO_BREAK_SPACE . '».', $fixer->fix('Oh my god, this quote is alone: " ! But those are "ok".'));
     }
 
-    protected function basicStringsAsserts($fixer)
+    protected function basicStringsAsserts(FixerInterface $fixer): void
     {
         $this->assertSame('«' . Fixer::NO_BREAK_SPACE . 'Good code is like a good joke.' . Fixer::NO_BREAK_SPACE . '»', $fixer->fix('"Good code is like a good joke."'));
         $this->assertSame('«' . Fixer::NO_BREAK_SPACE . 'Good code is like a Bieber.' . Fixer::NO_BREAK_SPACE . '» - said no ever, ever.', $fixer->fix('"Good code is like a Bieber." - said no ever, ever.'));

--- a/tests/JoliTypo/Tests/Fixer/GermanQuotesTest.php
+++ b/tests/JoliTypo/Tests/Fixer/GermanQuotesTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 class GermanQuotesTest extends TestCase
 {
-    public function testSimpleString()
+    public function testSimpleString(): void
     {
         $fixer = new Fixer\GermanQuotes();
         $this->assertInstanceOf('JoliTypo\Fixer\GermanQuotes', $fixer);
@@ -22,14 +22,14 @@ class GermanQuotesTest extends TestCase
         $this->basicStringsAsserts($fixer);
     }
 
-    public function testSmartQuoteConfig()
+    public function testSmartQuoteConfig(): void
     {
         $fixer = new Fixer\SmartQuotes('de');
 
         $this->basicStringsAsserts($fixer);
     }
 
-    public function testFalsePositives()
+    public function testFalsePositives(): void
     {
         $fixer = new Fixer\GermanQuotes();
 
@@ -37,7 +37,7 @@ class GermanQuotesTest extends TestCase
         $this->assertSame('2"44\'.', $fixer->fix('2"44\'.'));
     }
 
-    protected function basicStringsAsserts($fixer)
+    protected function basicStringsAsserts($fixer): void
     {
         $this->assertSame('„I am smart“', $fixer->fix('"I am smart"'));
         $this->assertSame('(„I am smart“)', $fixer->fix('("I am smart")'));

--- a/tests/JoliTypo/Tests/Fixer/HyphenTest.php
+++ b/tests/JoliTypo/Tests/Fixer/HyphenTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 class HyphenTest extends TestCase
 {
-    public function testSimpleString()
+    public function testSimpleString(): void
     {
         $fixer = new Fixer\Hyphen('fr');
         $this->assertInstanceOf('JoliTypo\Fixer\Hyphen', $fixer);
@@ -24,7 +24,7 @@ class HyphenTest extends TestCase
         $this->assertSame('Cordia' . Fixer::SHY . 'le' . Fixer::SHY . 'ment' . Fixer::NO_BREAK_THIN_SPACE . '!', $fixer->fix('Cordialement' . Fixer::NO_BREAK_THIN_SPACE . '!'));
     }
 
-    public function testLocaleFallback()
+    public function testLocaleFallback(): void
     {
         $fixer = new Fixer\Hyphen('fr_BE');
         $this->assertInstanceOf('JoliTypo\Fixer\Hyphen', $fixer);
@@ -33,7 +33,7 @@ class HyphenTest extends TestCase
         $this->assertSame('Cordia' . Fixer::SHY . 'le' . Fixer::SHY . 'ment', $fixer->fix('Cordialement'));
     }
 
-    public function testNonExistingLocale()
+    public function testNonExistingLocale(): void
     {
         $fixer = new Fixer\Hyphen('toto');
 

--- a/tests/JoliTypo/Tests/Fixer/NoSpaceBeforeCommaTest.php
+++ b/tests/JoliTypo/Tests/Fixer/NoSpaceBeforeCommaTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 class NoSpaceBeforeCommaTest extends TestCase
 {
-    public function testSimpleString()
+    public function testSimpleString(): void
     {
         $fixer = new Fixer\NoSpaceBeforeComma();
         $this->assertInstanceOf('JoliTypo\Fixer\NoSpaceBeforeComma', $fixer);

--- a/tests/JoliTypo/Tests/Fixer/SmartQuotesTest.php
+++ b/tests/JoliTypo/Tests/Fixer/SmartQuotesTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 class SmartQuotesTest extends TestCase
 {
-    public function testSimpleString()
+    public function testSimpleString(): void
     {
         $fixer = new Fixer\SmartQuotes('de');
         $this->assertInstanceOf('JoliTypo\Fixer\SmartQuotes', $fixer);
@@ -33,7 +33,7 @@ class SmartQuotesTest extends TestCase
         $this->assertSame('<I am smart>', $fixer->fix('"I am smart"'));
     }
 
-    public function testBadConfig()
+    public function testBadConfig(): void
     {
         $this->expectException(BadFixerConfigurationException::class);
 

--- a/tests/JoliTypo/Tests/Fixer/TrademarkTest.php
+++ b/tests/JoliTypo/Tests/Fixer/TrademarkTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 class TrademarkTest extends TestCase
 {
-    public function testSimpleString()
+    public function testSimpleString(): void
     {
         $fixer = new Fixer\Trademark();
         $this->assertInstanceOf('JoliTypo\Fixer\Trademark', $fixer);
@@ -32,7 +32,7 @@ class TrademarkTest extends TestCase
     /**
      * :-( :sadface:.
      */
-    public function testImpossible()
+    public function testImpossible(): void
     {
         $this->markTestSkipped("Those tests can't pass: they are edge case JoliTypo does not cover ATM. Feel free to fix!");
 

--- a/tests/JoliTypo/Tests/Fixer/UnitTest.php
+++ b/tests/JoliTypo/Tests/Fixer/UnitTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 class UnitTest extends TestCase
 {
-    public function testNumericUnits()
+    public function testNumericUnits(): void
     {
         $fixer = new Fixer\Unit();
         $this->assertInstanceOf('JoliTypo\Fixer\Unit', $fixer);

--- a/tests/JoliTypo/Tests/FrenchTest.php
+++ b/tests/JoliTypo/Tests/FrenchTest.php
@@ -63,7 +63,7 @@ class FrenchTest extends TestCase
         FIXED;
     private $fr_fixers = ['Unit', 'Ellipsis', 'Dimension', 'Dash', 'SmartQuotes', 'FrenchNoBreakSpace', 'CurlyQuote', 'Hyphen', 'Trademark'];
 
-    public function testFixFullText()
+    public function testFixFullText(): void
     {
         $fixer = new Fixer($this->fr_fixers);
         $fixer->setLocale('fr_FR');
@@ -72,7 +72,7 @@ class FrenchTest extends TestCase
         $this->assertSame(self::FIXED, $fixer->fix(self::TOFIX));
     }
 
-    public function testFixFullTextShort()
+    public function testFixFullTextShort(): void
     {
         $fixer = new Fixer($this->fr_fixers);
         $fixer->setLocale('fr');
@@ -81,7 +81,7 @@ class FrenchTest extends TestCase
         $this->assertSame(self::FIXED, $fixer->fix(self::TOFIX));
     }
 
-    public function testDoubleQuoteMess()
+    public function testDoubleQuoteMess(): void
     {
         $fixer = new Fixer($this->fr_fixers);
         $fixer->setLocale('fr');
@@ -100,7 +100,7 @@ class FrenchTest extends TestCase
         $this->assertSame($fixed, $fixer->fix($to_fix));
     }
 
-    public function testEncodingMess()
+    public function testEncodingMess(): void
     {
         $fixer = new Fixer($this->fr_fixers);
         $fixer->setLocale('fr');
@@ -120,7 +120,7 @@ class FrenchTest extends TestCase
     /**
      * @see https://github.com/jolicode/JoliTypo/issues/16
      */
-    public function testNoBreakingSpaceInsideGoodQuotes()
+    public function testNoBreakingSpaceInsideGoodQuotes(): void
     {
         $fixer = new Fixer($this->fr_fixers);
 
@@ -147,7 +147,7 @@ class FrenchTest extends TestCase
     /**
      * @see https://github.com/jolicode/JoliTypo/issues/15
      */
-    public function testNumericDoesNotBreakOtherFixers()
+    public function testNumericDoesNotBreakOtherFixers(): void
     {
         $fixer = new Fixer($this->fr_fixers);
 
@@ -168,7 +168,7 @@ class FrenchTest extends TestCase
     /**
      * @see https://github.com/jolicode/JoliTypo/issues/35
      */
-    public function testWeirdHyphen()
+    public function testWeirdHyphen(): void
     {
         $fixer = new Fixer($this->fr_fixers);
 

--- a/tests/JoliTypo/Tests/Html5Test.php
+++ b/tests/JoliTypo/Tests/Html5Test.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 class Html5Test extends TestCase
 {
-    public function testHtml5Markup()
+    public function testHtml5Markup(): void
     {
         $fixer = new Fixer([new Fixer\Ellipsis()]);
         $this->assertInstanceOf('JoliTypo\Fixer', $fixer);
@@ -27,7 +27,7 @@ class Html5Test extends TestCase
         $this->assertSame($html5, $fixer->fix($html5));
     }
 
-    public function testFullPageMarkup()
+    public function testFullPageMarkup(): void
     {
         $fixer = new Fixer([new Fixer\EnglishQuotes()]);
         $this->assertInstanceOf('JoliTypo\Fixer', $fixer);

--- a/tests/JoliTypo/Tests/JoliTypoTest.php
+++ b/tests/JoliTypo/Tests/JoliTypoTest.php
@@ -191,7 +191,7 @@ class FakeFixer
 
 class OkFixer implements FixerInterface
 {
-    public function fix($content, StateBag $stateBag = null)
+    public function fix(string $content, ?StateBag $stateBag): string
     {
         return $content;
     }

--- a/tests/JoliTypo/Tests/JoliTypoTest.php
+++ b/tests/JoliTypo/Tests/JoliTypoTest.php
@@ -191,7 +191,7 @@ class FakeFixer
 
 class OkFixer implements FixerInterface
 {
-    public function fix(string $content, ?StateBag $stateBag): string
+    public function fix(string $content, ?StateBag $stateBag = null): string
     {
         return $content;
     }

--- a/tests/JoliTypo/Tests/JoliTypoTest.php
+++ b/tests/JoliTypo/Tests/JoliTypoTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
 
 class JoliTypoTest extends TestCase
 {
-    public function testSimpleInstance()
+    public function testSimpleInstance(): void
     {
         $fixer = new Fixer(['Ellipsis']);
         $this->assertInstanceOf('JoliTypo\Fixer', $fixer);
@@ -25,7 +25,7 @@ class JoliTypoTest extends TestCase
         $this->assertSame('Coucou&hellip;', $fixer->fix('Coucou...'));
     }
 
-    public function testSimpleInstanceRulesChange()
+    public function testSimpleInstanceRulesChange(): void
     {
         $fixer = new Fixer(['Ellipsis']);
         $this->assertInstanceOf('JoliTypo\Fixer', $fixer);
@@ -37,7 +37,7 @@ class JoliTypoTest extends TestCase
         $this->assertSame('I&rsquo;m a pony.', $fixer->fix("I'm a pony."));
     }
 
-    public function testHtmlComments()
+    public function testHtmlComments(): void
     {
         $fixer = new Fixer(['Ellipsis']);
         $this->assertSame('<p>Coucou&hellip;</p> <!-- Not Coucou... -->', $fixer->fix('<p>Coucou...</p> <!-- Not Coucou... -->'));
@@ -46,14 +46,14 @@ class JoliTypoTest extends TestCase
         // $this->assertSame("<p>Coucou&hellip;</p> <!-- abusé -->", $fixer->fix("<p>Coucou...</p> <!-- abusé -->"));
     }
 
-    public function testBadRuleSetsWithEmptyArray()
+    public function testBadRuleSetsWithEmptyArray(): void
     {
         $this->expectException(BadRuleSetException::class);
 
         new Fixer([]);
     }
 
-    public function testBadRuleSetsWithEmptyArrayAfterConstructor()
+    public function testBadRuleSetsWithEmptyArrayAfterConstructor(): void
     {
         $this->expectException(BadRuleSetException::class);
 
@@ -61,21 +61,21 @@ class JoliTypoTest extends TestCase
         $fixer->setRules([]);
     }
 
-    public function testInvalidCustomFixerInstance()
+    public function testInvalidCustomFixerInstance(): void
     {
         $this->expectException(BadRuleSetException::class);
 
         new Fixer([new FakeFixer()]);
     }
 
-    public function testOkFixer()
+    public function testOkFixer(): void
     {
         $fixer = new Fixer([new OkFixer()]);
 
         $this->assertSame('<p>Nope !</p>', $fixer->fix('<p>Nope !</p>'));
     }
 
-    public function testProtectedTags()
+    public function testProtectedTags(): void
     {
         $fixer = new Fixer(['Ellipsis']);
         $fixer->setProtectedTags(['pre', 'a']);
@@ -84,14 +84,14 @@ class JoliTypoTest extends TestCase
         $this->assertSame('<p>Fixed&hellip;</p> <pre>Not fixed...</pre> <p>Fixed&hellip; <a>Not Fixed...</a>.</p>', $fixed_content);
     }
 
-    public function testBadClassName()
+    public function testBadClassName(): void
     {
         $this->expectException(BadRuleSetException::class);
 
         new Fixer(['Ellipsis', 'Acme\\Demo\\Fixer']);
     }
 
-    public function testBadLocale()
+    public function testBadLocale(): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
@@ -99,14 +99,14 @@ class JoliTypoTest extends TestCase
         $fixer->setLocale(false);
     }
 
-    public function testEmptyRules()
+    public function testEmptyRules(): void
     {
         $this->expectException(BadRuleSetException::class);
 
         new Fixer([]);
     }
 
-    public function testXmlPrefixedContent()
+    public function testXmlPrefixedContent(): void
     {
         $fixer = new Fixer(['Ellipsis']);
         $this->assertInstanceOf('JoliTypo\Fixer', $fixer);
@@ -115,7 +115,7 @@ class JoliTypoTest extends TestCase
         $this->assertSame('<p>Hey &eacute;pic dude&hellip;</p>', $fixer->fix('<?xml encoding="ISO-8859-1"><body><p>Hey épic dude...</p></body>'));
     }
 
-    public function testBadEncoding()
+    public function testBadEncoding(): void
     {
         $fixer = new Fixer(['Trademark']);
         $this->assertInstanceOf('JoliTypo\Fixer', $fixer);
@@ -129,7 +129,7 @@ class JoliTypoTest extends TestCase
         $this->assertSame('Mentions L&Atilde;&copy;gales', $fixer->fix(utf8_encode(utf8_encode($isoString))));
     }
 
-    public function testEmptyContent()
+    public function testEmptyContent(): void
     {
         $fixer = new Fixer(['Trademark']);
         $this->assertInstanceOf('JoliTypo\Fixer', $fixer);
@@ -139,7 +139,7 @@ class JoliTypoTest extends TestCase
         $this->assertSame('some content &reg;', $fixer->fix("\n some content (r)"));
     }
 
-    public function testNonHTMLContent()
+    public function testNonHTMLContent(): void
     {
         $fixer = new Fixer(['Trademark', 'SmartQuotes']);
         $this->assertInstanceOf('JoliTypo\Fixer', $fixer);
@@ -161,7 +161,7 @@ class JoliTypoTest extends TestCase
     }
 
     /** @group legacy */
-    public function testDeprecatedFixer()
+    public function testDeprecatedFixer(): void
     {
         $fixer = new Fixer(['Numeric']);
         $this->assertInstanceOf('JoliTypo\Fixer', $fixer);

--- a/tests/JoliTypo/Tests/JoliTypoTest.php
+++ b/tests/JoliTypo/Tests/JoliTypoTest.php
@@ -46,34 +46,19 @@ class JoliTypoTest extends TestCase
         // $this->assertSame("<p>Coucou&hellip;</p> <!-- abusé -->", $fixer->fix("<p>Coucou...</p> <!-- abusé -->"));
     }
 
-    public function testBadRuleSets()
-    {
-        $this->expectException(BadRuleSetException::class);
-
-        new Fixer('YOLO');
-    }
-
-    public function testBadRuleSetsArray()
+    public function testBadRuleSetsWithEmptyArray()
     {
         $this->expectException(BadRuleSetException::class);
 
         new Fixer([]);
     }
 
-    public function testBadRuleSetsAfterConstructor()
+    public function testBadRuleSetsWithEmptyArrayAfterConstructor()
     {
         $this->expectException(BadRuleSetException::class);
 
         $fixer = new Fixer(['Ellipsis']);
-        $fixer->setRules('YOLO');
-    }
-
-    public function testInvalidProtectedTags()
-    {
-        $this->expectException(\InvalidArgumentException::class);
-
-        $fixer = new Fixer(['Ellipsis']);
-        $fixer->setProtectedTags('YOLO');
+        $fixer->setRules([]);
     }
 
     public function testInvalidCustomFixerInstance()

--- a/tests/JoliTypo/Tests/JoliTypoTest.php
+++ b/tests/JoliTypo/Tests/JoliTypoTest.php
@@ -176,7 +176,7 @@ class FakeFixer
 
 class OkFixer implements FixerInterface
 {
-    public function fix(string $content, ?StateBag $stateBag = null): string
+    public function fix(string $content, ?StateBag $stateBag = null)
     {
         return $content;
     }


### PR DESCRIPTION
## CHANGES

* As the title says, this PR concerns upgrading our code base to support type declaration features that are added in PHP version `7.4` and prior.

## EXPLANATION

JoliTypo support only `>=7.4` PHP versions, so we can take advantage of all PHP `<=7.4` features to upgrade our library code base, this PR focused mainly on the integration of the following features (others features can be integrated later):

* [Typed Properties](https://www.php.net/manual/en/migration74.new-features.php#migration74.new-features.core.typed-properties) (*>= v7.4*).
* [Scalar Type Declarations](https://www.php.net/manual/en/migration70.new-features.php#migration70.new-features.scalar-type-declarations) (*>= v7.0*).
* [Return type declarations](https://www.php.net/manual/en/migration70.new-features.php#migration70.new-features.return-type-declarations) (*>= v7.0*).

## IMPORTANT NOTES

### BREAKING CHANGE

This is a breaking change, if this PR is approved and planned to get merged, I suggest doing so in the next major version of JoliTypo (version `2.0.0`), because if these changes get merged and a non-breaking version is released `1.x.x`, and one of our library users has their own implementation of our fixer interface (`FixerInterface`) or just they extends our classes and they override parent methods, then they will get some PHP fatal errors, this is a simple example that demonstrates this scenario:

```php
interface FixerInterface
{
    public function fix(string $content, ?StateBag $stateBag = null): string;
}

/**
 * Example of a fixer that extends the fixer interface
 */
class CustomFixer implements FixerInterface
{
    public function fix(string $content, ?StateBag $stateBag = null)
    {
        //
    }
}
```

This code will trigger this error:

```
PHP Fatal error:  Declaration of CustomFixer::fix(string $content, ?JoliTypo\StateBag $stateBag = null) must be compatible with FixerInterface::fix(string $content, ?JoliTypo\StateBag $stateBag = null): string in ...
```

### STRICT MODE

By adding declaration types we actually do not strict our properties and function arguments to their declared types, instead, PHP will try to coerce values of wrong types into the closed expected type declaration. however strict typing is disabled by default and it can be enabled at runtime by doing `declare(strict_types=1);` on a per-file basis, if we planned to enable strict typing I suggest enabling strict typing in a different PR after merging this one if approved of course.

## CONCLUSION

If this PR is approved and merged I can work on other PRs to integrate the other `7.4` features and have our code base fully use PHP `<=7.4` features.
