### PR TITLE
Removed deprecated twig extension method (getName)

### DIFF
--- a/src/JoliTypo/Bridge/Twig/JoliTypoExtension.php
+++ b/src/JoliTypo/Bridge/Twig/JoliTypoExtension.php
@@ -46,9 +46,4 @@ class JoliTypoExtension extends AbstractExtension
 
         return $this->presets[$preset]->fix($text);
     }
-
-    public function getName(): string
-    {
-        return 'jolitypo';
-    }
 }


### PR DESCRIPTION
## CHANGES

As the title says, removed the `JoliTypoExtension::getName()` method.

https://twig.symfony.com/doc/1.x/deprecated.html