### PR TITLE
Change visibility of some Fixer properties into private

### DIFF
--- a/src/JoliTypo/Fixer.php
+++ b/src/JoliTypo/Fixer.php
@@ -52,7 +52,7 @@ class Fixer
      */
     private array $_rules = [];
 
-    private StateBag $stateBag;
+    private ?StateBag $stateBag = null;
 
     /**
      * @param array $rules Array of Fixer

--- a/src/JoliTypo/Fixer.php
+++ b/src/JoliTypo/Fixer.php
@@ -51,7 +51,7 @@ class Fixer
     /**
      * @var string The default locale (used by some Fixer)
      */
-    protected $locale = 'en_GB';
+    private $locale = 'en_GB';
 
     /**
      * @var array<FixerInterface> The rules Fixer instances to apply on each DOMText

--- a/src/JoliTypo/Fixer.php
+++ b/src/JoliTypo/Fixer.php
@@ -56,7 +56,7 @@ class Fixer
     /**
      * @var array<FixerInterface> The rules Fixer instances to apply on each DOMText
      */
-    protected $_rules = [];
+    private $_rules = [];
 
     /**
      * @var StateBag

--- a/src/JoliTypo/Fixer.php
+++ b/src/JoliTypo/Fixer.php
@@ -43,25 +43,16 @@ class Fixer
         'de_DE' => ['Ellipsis', 'Dimension', 'Unit', 'Dash', 'SmartQuotes', 'NoSpaceBeforeComma', 'CurlyQuote', 'Hyphen', 'Trademark'],
     ];
 
-    /**
-     * @var array HTML Tags to bypass
-     */
-    private $protectedTags = ['head', 'link', 'pre', 'code', 'script', 'style'];
+    private array $protectedTags = ['head', 'link', 'pre', 'code', 'script', 'style'];
 
-    /**
-     * @var string The default locale (used by some Fixer)
-     */
-    private $locale = 'en_GB';
+    private string $locale = 'en_GB';
 
     /**
      * @var array<FixerInterface> The rules Fixer instances to apply on each DOMText
      */
-    private $_rules = [];
+    private array $_rules = [];
 
-    /**
-     * @var StateBag
-     */
-    private $stateBag;
+    private StateBag $stateBag;
 
     /**
      * @param array $rules Array of Fixer
@@ -183,6 +174,11 @@ class Fixer
         }
 
         return $locale;
+    }
+
+    protected function getStateBug(): StateBag
+    {
+        return $this->stateBag;
     }
 
     /**

--- a/src/JoliTypo/Fixer.php
+++ b/src/JoliTypo/Fixer.php
@@ -46,7 +46,7 @@ class Fixer
     /**
      * @var array HTML Tags to bypass
      */
-    protected $protectedTags = ['head', 'link', 'pre', 'code', 'script', 'style'];
+    private $protectedTags = ['head', 'link', 'pre', 'code', 'script', 'style'];
 
     /**
      * @var string The default locale (used by some Fixer)

--- a/src/JoliTypo/Fixer.php
+++ b/src/JoliTypo/Fixer.php
@@ -119,6 +119,11 @@ class Fixer
         $this->compileRules($rules);
     }
 
+    public function getProtectedTags(): array
+    {
+        return $this->protectedTags;
+    }
+
     /**
      * Customize the list of protected tags.
      *

--- a/src/JoliTypo/Fixer.php
+++ b/src/JoliTypo/Fixer.php
@@ -61,7 +61,7 @@ class Fixer
     /**
      * @var StateBag
      */
-    protected $stateBag;
+    private $stateBag;
 
     /**
      * @param array $rules Array of Fixer


### PR DESCRIPTION
## CHANGES

* Convert visibility of properties (`protectedTags`, `locale`, `_rules`, `stateBag`) from protected into private.
* Added getter for `protectedTags` property.

## NOTES

* For the `stateBag` property I didn't add a getter for it because it is used only in a private part of the fixer class, if a user needs an instance of the `StateBag` class, he can have his own property in his derived class.