### PR TITLE
ci: Fix branch name for gh-pages

### DIFF
--- a/.github/workflows/ghpages.yaml
+++ b/.github/workflows/ghpages.yaml
@@ -3,7 +3,7 @@ name: Build the public website, and publish to GitHub Pages
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "master" ]
 
 permissions:
   contents: read


### PR DESCRIPTION
**WARNING** IMHO, instead of this PR, we should update the default branch from `master` to `main`. WDYT?